### PR TITLE
Fixes and polling change

### DIFF
--- a/_examples/QueryManipulation/QueryManipulation.go
+++ b/_examples/QueryManipulation/QueryManipulation.go
@@ -38,16 +38,16 @@ func main() {
 	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 
 	httpClient := &http.Client{}
-	httpClient.Transport = transport
+	//httpClient.Transport = transport
 
 	cx1client, err := Cx1ClientGo.NewAPIKeyClient(httpClient, base_url, iam_url, tenant, api_key, logger)
 	if err != nil {
 		logger.Fatalf("Error creating client: %s", err)
 	}
 
-	project, err := cx1client.GetProjectByName("ssba-anotheraudittest")
+	project, err := cx1client.GetProjectByName("test-project")
 	if err != nil {
-		logger.Fatalf("Error getting project: %s", err)
+		logger.Fatalf("Error getting project 'test-project': %s", err)
 	}
 
 	lastscans, err := cx1client.GetLastScansByStatusAndID(project.ProjectID, 1, []string{"Completed"})
@@ -62,13 +62,47 @@ func main() {
 		logger.Fatalf("Error getting an audit session: %s", err)
 	}
 
-	newCorpOverride(cx1client, logger, session)
-	newProjectOverride(cx1client, logger, session, project.ProjectID)
-	newCorpQuery(cx1client, logger, session)
+	application, err := cx1client.GetApplicationByName("test-application")
+	if err != nil {
+		logger.Fatalf("Error getting application 'test-application': %s", err)
+	}
 
+	corpOverride := newCorpOverride(cx1client, logger, session)
+	appOverride := newApplicationOverride(cx1client, logger, session, application.ApplicationID)
+	projOverride := newProjectOverride(cx1client, logger, session, project.ProjectID)
+	corpQuery := newCorpQuery(cx1client, logger, session)
+
+	logger.Infof("The following custom (not Cx-level) queries exist for project Id %v", project.ProjectID)
+	queries, err := cx1client.GetQueriesByLevelID("Project", project.ProjectID)
+	if err != nil {
+		logger.Warnf("Failed to get queries for project: %s", err)
+	} else {
+		for _, q := range queries {
+			if q.Level != "Cx" {
+				logger.Infof(" - %v", q.String())
+			}
+		}
+	}
+
+	err = cx1client.DeleteQuery(projOverride)
+	if err != nil {
+		logger.Warnf("Failed to delete project query %v: %s", projOverride.String(), err)
+	}
+	err = cx1client.DeleteQuery(appOverride)
+	if err != nil {
+		logger.Warnf("Failed to delete application query %v: %s", appOverride.String(), err)
+	}
+	err = cx1client.DeleteQuery(corpOverride)
+	if err != nil {
+		logger.Warnf("Failed to delete corp query %v: %s", corpOverride.String(), err)
+	}
+	err = cx1client.DeleteQuery(corpQuery)
+	if err != nil {
+		logger.Warnf("Failed to delete corp query %v: %s", corpQuery.String(), err)
+	}
 }
 
-func newCorpOverride(cx1client *Cx1ClientGo.Cx1Client, logger *logrus.Logger, session string) {
+func newCorpOverride(cx1client *Cx1ClientGo.Cx1Client, logger *logrus.Logger, session string) Cx1ClientGo.AuditQuery {
 	// First query: Tenant-level override of an existing query
 	baseQuery, err := cx1client.GetQueryByName("Cx", "Java", "Java_Spring", "Spring_Missing_Expect_CT_Header")
 	if err != nil {
@@ -101,18 +135,47 @@ func newCorpOverride(cx1client *Cx1ClientGo.Cx1Client, logger *logrus.Logger, se
 	}
 
 	logger.Infof("Created new corp override: %v", nq)
-
-	// now delete it
-	//err = cx1client.DeleteQueryByName( "Corp", lang, group, query )
-	err = cx1client.DeleteQuery(newCorpOverride)
-	if err != nil {
-		logger.Fatalf("Error deleting query: %s", err)
-	} else {
-		logger.Infof("Query deleted")
-	}
+	return nq
 }
 
-func newProjectOverride(cx1client *Cx1ClientGo.Cx1Client, logger *logrus.Logger, session, projectId string) {
+func newApplicationOverride(cx1client *Cx1ClientGo.Cx1Client, logger *logrus.Logger, session, applicationId string) Cx1ClientGo.AuditQuery {
+	// First query: Tenant-level override of an existing query
+	baseQuery, err := cx1client.GetQueryByName("Cx", "Java", "Java_Spring", "Spring_Missing_Expect_CT_Header")
+	if err != nil {
+		logger.Fatalf("Error getting query: %s", err)
+	}
+	// Second query: project-level override of existing query
+	cx1client.AuditSessionKeepAlive(session)
+	newApplicationOverride := baseQuery.CreateProjectOverrideByID(applicationId)
+	newApplicationOverride.Source = "result = base.Spring_Missing_Expect_CT_Header(); // project override"
+
+	err = cx1client.AuditCompileQuery(session, newApplicationOverride)
+	if err != nil {
+		logger.Fatalf("Error triggering query compile: %s", err)
+	}
+
+	err = cx1client.AuditCompilePollingByID(session)
+	if err != nil {
+		logger.Fatalf("Error while polling compiler: %s", err)
+	}
+
+	err = cx1client.UpdateQuery(newApplicationOverride)
+	if err != nil {
+		logger.Fatalf("Error saving new query: %s", err)
+	} else {
+		logger.Infof("Saved new query %v", newApplicationOverride.String())
+	}
+
+	nq, err := cx1client.GetQueryByName(applicationId, "Java", "Java_Spring", "Spring_Missing_Expect_CT_Header")
+	if err != nil {
+		logger.Fatalf("Failed to get new project override: %s", err)
+	}
+
+	logger.Infof("Created new application override: %v", nq)
+	return nq
+}
+
+func newProjectOverride(cx1client *Cx1ClientGo.Cx1Client, logger *logrus.Logger, session, projectId string) Cx1ClientGo.AuditQuery {
 	// First query: Tenant-level override of an existing query
 	baseQuery, err := cx1client.GetQueryByName("Cx", "Java", "Java_Spring", "Spring_Missing_Expect_CT_Header")
 	if err != nil {
@@ -145,19 +208,11 @@ func newProjectOverride(cx1client *Cx1ClientGo.Cx1Client, logger *logrus.Logger,
 		logger.Fatalf("Failed to get new project override: %s", err)
 	}
 
-	logger.Infof("Created new corp query: %v", nq)
-
-	// now delete it
-	//err = cx1client.DeleteQueryByName( project.ProjectID, lang, group, query )
-	err = cx1client.DeleteQuery(newProjectOverride)
-	if err != nil {
-		logger.Fatalf("Error deleting query: %s", err)
-	} else {
-		logger.Infof("Query deleted")
-	}
+	logger.Infof("Created new project override: %v", nq)
+	return nq
 }
 
-func newCorpQuery(cx1client *Cx1ClientGo.Cx1Client, logger *logrus.Logger, session string) {
+func newCorpQuery(cx1client *Cx1ClientGo.Cx1Client, logger *logrus.Logger, session string) Cx1ClientGo.AuditQuery {
 	// Third query: create new corp/tenant query
 	cx1client.AuditSessionKeepAlive(session)
 	newQuery, err := cx1client.AuditNewQuery("Java", "Java_Spring", "TestQuery")
@@ -195,13 +250,5 @@ func newCorpQuery(cx1client *Cx1ClientGo.Cx1Client, logger *logrus.Logger, sessi
 	}
 
 	logger.Infof("Created new corp query: %v", nq)
-
-	// now delete it
-	//err = cx1client.DeleteQueryByName( "Corp", lang, group, query )
-	err = cx1client.DeleteQuery(newQuery)
-	if err != nil {
-		logger.Fatalf("Error deleting query: %s", err)
-	} else {
-		logger.Infof("Query deleted")
-	}
+	return nq
 }

--- a/cx1client.go
+++ b/cx1client.go
@@ -243,6 +243,15 @@ func (c *Cx1Client) InitializeClient() {
 	if err != nil {
 		c.logger.Warnf("Failed to get tenant flags: %s", err)
 	}
+
+	c.consts.MigrationPollingMaxSeconds = 20 * 15
+	c.consts.MigrationPollingDelaySeconds = 15
+	c.consts.EnginePollingMaxSeconds = 20 * 15
+	c.consts.EnginePollingDelaySeconds = 15
+	c.consts.ScanPollingMaxSeconds = 40 * 15
+	c.consts.ScanPollingDelaySeconds = 15
+	c.consts.LanguagePollingMaxSeconds = 20 * 15
+	c.consts.LanguagePollingDelaySeconds = 15
 }
 
 func (c *Cx1Client) RefreshFlags() error {
@@ -286,4 +295,13 @@ func (c Cx1Client) CheckFlag(flag string) (bool, error) {
 	}
 
 	return setting, nil
+}
+
+func (c Cx1Client) GetClientVars() ClientVars {
+	c.logger.Info("Retrieving client vars - polling limits set in seconds")
+	return c.consts
+}
+
+func (c *Cx1Client) SetClientVars(clientvars ClientVars) {
+	c.consts = clientvars
 }

--- a/migration.go
+++ b/migration.go
@@ -9,9 +9,7 @@ import (
 	"time"
 )
 
-const (
-	MigrationPollingMax = 20
-)
+//var MigrationPollingMax int = 20
 
 func (c Cx1Client) StartMigration(dataArchive, projectMapping []byte, encryptionKey string) (string, error) {
 	dataUrl, err := c.UploadBytes(&dataArchive)
@@ -106,11 +104,11 @@ func (c Cx1Client) ImportPollingByID(importID string) (string, error) {
 		case "partial":
 			return status.Status, nil
 		}
-		counter++
-		if counter >= MigrationPollingMax {
-			return "timeout", fmt.Errorf("import polling reached max count %d, aborting", counter)
+		counter += c.consts.MigrationPollingDelaySeconds
+		if counter >= c.consts.MigrationPollingMaxSeconds {
+			return "timeout", fmt.Errorf("import polling reached %d seconds, aborting - use cx1client.get/setclientvars to change", counter)
 		}
-		time.Sleep(10 * time.Second)
+		time.Sleep(time.Duration(c.consts.MigrationPollingDelaySeconds) * time.Second)
 	}
 }
 

--- a/queries.go
+++ b/queries.go
@@ -610,7 +610,7 @@ func (q AuditQuery) CreateProjectOverrideByID(projectId string) AuditQuery {
 }
 func (q AuditQuery) CreateApplicationOverrideByID(applicationId string) AuditQuery {
 	new_query := q
-	new_query.Level = "Application"
+	new_query.Level = "Team"
 	new_query.LevelID = applicationId
 	return new_query
 }

--- a/queries.go
+++ b/queries.go
@@ -103,12 +103,13 @@ func (c Cx1Client) DeleteQueryByName(level, levelID, language, group, query stri
 	_, err := c.sendRequest(http.MethodDelete, fmt.Sprintf("/cx-audit/queries/%v/%v.cs", levelID, path), nil, nil)
 	if err != nil {
 		// currently there's a bug where the response can be error 500 even if it succeeded.
-		queries, err2 := c.GetQueriesByLevelID(level, levelID)
+
+		q, err2 := c.GetQueryByName(levelID, language, group, query)
 		if err2 != nil {
 			return fmt.Errorf("error while deleting query (%s) followed by error while checking if the query was deleted (%s)", err, err2)
 		}
-		q, err2 := FindQueryByName(queries, level, language, group, query)
-		if err2 != nil {
+
+		if q.Level != level {
 			c.logger.Warnf("While deleting the query an error was returned (%s) but the query was deleted", err)
 			return nil
 		} else {

--- a/types.go
+++ b/types.go
@@ -15,6 +15,18 @@ type Cx1Client struct {
 	tenant  string
 	logger  *logrus.Logger
 	flags   map[string]bool // initial implementation ignoring "payload" part of the flag
+	consts  ClientVars
+}
+
+type ClientVars struct {
+	MigrationPollingMaxSeconds   int
+	MigrationPollingDelaySeconds int
+	EnginePollingMaxSeconds      int
+	EnginePollingDelaySeconds    int
+	ScanPollingMaxSeconds        int
+	ScanPollingDelaySeconds      int
+	LanguagePollingMaxSeconds    int
+	LanguagePollingDelaySeconds  int
 }
 
 type AccessAssignment struct {

--- a/types.go
+++ b/types.go
@@ -14,6 +14,7 @@ type Cx1Client struct {
 	iamUrl  string
 	tenant  string
 	logger  *logrus.Logger
+	flags   map[string]bool // initial implementation ignoring "payload" part of the flag
 }
 
 type AccessAssignment struct {


### PR DESCRIPTION
There was an issue in my workaround for deleting queries which also threw errors when deleting application-level queries, this has been hopefully fixed.
There were some constants set to limit polling of different processes (audit-related and also during migration-import) and these have been exposed via cx1client.getclientvars and setclientvars.