### PR TITLE
Fix consistency cleanup

### DIFF
--- a/applications.go
+++ b/applications.go
@@ -116,9 +116,8 @@ func (c Cx1Client) CreateApplication(appname string) (Application, error) {
 	return app, err
 }
 
-func (c Cx1Client) DeleteApplication(applicationId string) error {
-	c.depwarn("DeleteApplication", "DeleteApplicationByID")
-	return c.DeleteApplicationByID(applicationId)
+func (c Cx1Client) DeleteApplication(application *Application) error {
+	return c.DeleteApplicationByID(application.ApplicationID)
 }
 func (c Cx1Client) DeleteApplicationByID(applicationId string) error {
 	c.logger.Debugf("Delete Application: %v", applicationId)
@@ -183,10 +182,6 @@ func (a *Application) String() string {
 	return fmt.Sprintf("[%v] %v", ShortenGUID(a.ApplicationID), a.Name)
 }
 
-func (c Cx1Client) GetOrCreateApplication(name string) (Application, error) {
-	c.depwarn("GetOrCreateApplication", "GetOrCreateApplicationByName")
-	return c.GetOrCreateApplicationByName(name)
-}
 func (c Cx1Client) GetOrCreateApplicationByName(name string) (Application, error) {
 	app, err := c.GetApplicationByName(name)
 	if err == nil {

--- a/audit.go
+++ b/audit.go
@@ -163,12 +163,6 @@ func (c Cx1Client) AuditRequestStatusPollingByID(auditSession *AuditSession, req
 	return c.AuditRequestStatusPollingByIDWithTimeout(auditSession, requestId, c.consts.AuditEnginePollingDelaySeconds, c.consts.AuditEnginePollingMaxSeconds)
 }
 
-// this function should've always been called AuditRequestStatusPollingByIDWithTimeout
-func (c Cx1Client) AuditRequestStatusByIDWithTimeout(auditSession *AuditSession, requestId string, delaySeconds, maxSeconds int) (interface{}, error) {
-	c.depwarn("AuditRequestStatusByIDWithTimeout", "AuditRequestStatusPollingByIDWithTimeout")
-	return c.AuditRequestStatusPollingByIDWithTimeout(auditSession, requestId, c.consts.AuditEnginePollingDelaySeconds, c.consts.AuditEnginePollingMaxSeconds)
-}
-
 func (c Cx1Client) AuditRequestStatusPollingByIDWithTimeout(auditSession *AuditSession, requestId string, delaySeconds, maxSeconds int) (interface{}, error) {
 	c.logger.Debugf("Polling status of request %v for audit session %v", requestId, auditSession.ID)
 	var value interface{}

--- a/groups.go
+++ b/groups.go
@@ -425,10 +425,6 @@ func (c Cx1Client) GetGroupMembersByID(groupID string) ([]User, error) {
 }
 
 // convenience
-func (c Cx1Client) GetOrCreateGroup(name string) (Group, error) {
-	c.depwarn("GetOrCreateGroup", "GetOrCreateGroupByName")
-	return c.GetOrCreateGroupByName(name)
-}
 func (c Cx1Client) GetOrCreateGroupByName(name string) (Group, error) {
 	group, err := c.GetGroupByName(name)
 	if err != nil {

--- a/projects.go
+++ b/projects.go
@@ -234,11 +234,6 @@ func (c Cx1Client) GetProjectsByName(projectname string, limit uint64) ([]Projec
 	return ProjectResponse.Projects, nil
 }
 
-func (c Cx1Client) GetProjectsByNameAndGroup(projectName string, groupID string) ([]Project, error) {
-	c.depwarn("GetProjectsByNameAndGroup", "GetProjectsByNameAndGroupID")
-	return c.GetProjectsByNameAndGroupID(projectName, groupID)
-}
-
 func (c Cx1Client) GetProjectsByNameAndGroupID(projectName string, groupID string) ([]Project, error) {
 	c.logger.Debugf("Getting projects with name %v of group ID %v...", projectName, groupID)
 
@@ -340,11 +335,6 @@ func (c Cx1Client) UpdateProjectConfigurationByID(projectID string, settings []C
 	return nil
 }
 
-func (c Cx1Client) SetProjectBranch(projectID, branch string, allowOverride bool) error {
-	c.depwarn("SetProjectBranch", "SetProjectBranchByID")
-	return c.SetProjectBranchByID(projectID, branch, allowOverride)
-}
-
 func (c Cx1Client) SetProjectBranchByID(projectID, branch string, allowOverride bool) error {
 	var setting ConfigurationSetting
 	setting.Key = "scan.handler.git.branch"
@@ -363,11 +353,6 @@ func (c Cx1Client) SetProjectRepositoryByID(projectID, repository string, allowO
 	return c.UpdateProjectConfigurationByID(projectID, []ConfigurationSetting{setting})
 }
 
-func (c Cx1Client) SetProjectPreset(projectID, presetName string, allowOverride bool) error {
-	c.depwarn("SetProjectPreset", "SetProjectPresetByID")
-	return c.SetProjectPresetByID(projectID, presetName, allowOverride)
-}
-
 func (c Cx1Client) SetProjectPresetByID(projectID, presetName string, allowOverride bool) error {
 	var setting ConfigurationSetting
 	setting.Key = "scan.config.sast.presetName"
@@ -377,11 +362,6 @@ func (c Cx1Client) SetProjectPresetByID(projectID, presetName string, allowOverr
 	return c.UpdateProjectConfigurationByID(projectID, []ConfigurationSetting{setting})
 }
 
-func (c Cx1Client) SetProjectLanguageMode(projectID, languageMode string, allowOverride bool) error {
-	c.depwarn("SetProjectLanguageMode", "SetProjectLanguageModeByID")
-	return c.SetProjectLanguageModeByID(projectID, languageMode, allowOverride)
-}
-
 func (c Cx1Client) SetProjectLanguageModeByID(projectID, languageMode string, allowOverride bool) error {
 	var setting ConfigurationSetting
 	setting.Key = "scan.config.sast.languageMode"
@@ -389,11 +369,6 @@ func (c Cx1Client) SetProjectLanguageModeByID(projectID, languageMode string, al
 	setting.AllowOverride = allowOverride
 
 	return c.UpdateProjectConfigurationByID(projectID, []ConfigurationSetting{setting})
-}
-
-func (c Cx1Client) SetProjectFileFilter(projectID, filter string, allowOverride bool) error {
-	c.depwarn("SetProjectFileFilter", "SetProjectFileFilterByID")
-	return c.SetProjectFileFilterByID(projectID, filter, allowOverride)
 }
 
 func (c Cx1Client) SetProjectFileFilterByID(projectID, filter string, allowOverride bool) error {
@@ -536,11 +511,6 @@ func (p *Project) AssignGroup(group *Group) {
 		return
 	}
 	p.Groups = append(p.Groups, group.GroupID)
-}
-
-func (c Cx1Client) GetOrCreateProject(name string) (Project, error) {
-	c.depwarn("GetOrCreateProject", "GetOrCreateProjectByName")
-	return c.GetOrCreateProjectByName(name)
 }
 
 func (c Cx1Client) GetOrCreateProjectByName(name string) (Project, error) {

--- a/queries.go
+++ b/queries.go
@@ -54,51 +54,6 @@ func (q AuditQuery_v312) ToQuery() Query {
 	}
 }
 
-/*
-func (c Cx1Client) GetQueryByName(level, language, group, query string) (AuditQuery, error) {
-	c.depwarn("GetQueryByName", "GetAuditQueryByName")
-	c.logger.Debugf("Get %v query by name: %v -> %v -> %v", level, language, group, query)
-	path := fmt.Sprintf("queries%%2F%v%%2F%v%%2F%v%%2F%v", language, group, query, query)
-
-	response, err := c.sendRequest(http.MethodGet, fmt.Sprintf("/cx-audit/queries/%v/%v.cs", level, path), nil, nil)
-	if err != nil {
-		return AuditQuery{}, err
-	}
-
-	var q AuditQuery
-	err = json.Unmarshal(response, &q)
-	if err != nil {
-		return q, err
-	}
-
-	q.LevelID = level
-
-	return q, nil
-}
-
-func (c Cx1Client) GetQueryByPath(level, path string) (AuditQuery, error) {
-	c.depwarn("GetQueryByPath", "GetAuditQueryByPath")
-	c.logger.Debugf("Get %v query by path: %v", level, path)
-
-	response, err := c.sendRequest(http.MethodGet, fmt.Sprintf("/cx-audit/queries/%v/%v", level, strings.Replace(path, "/", "%2f", -1)), nil, nil)
-	if err != nil {
-		return AuditQuery{}, err
-	}
-
-	var q AuditQuery
-	err = json.Unmarshal(response, &q)
-	if err != nil {
-		return q, err
-	}
-
-	if strings.EqualFold(q.Level, AUDIT_QUERY_TENANT) || strings.EqualFold(q.Level, AUDIT_QUERY_PRODUCT) {
-		q.LevelID = q.Level
-	} else { // team or project-level override, so store the ID
-		q.LevelID = level
-	}
-	return q, nil
-} */
-
 func (c Cx1Client) GetQueriesByLevelID(level, levelId string) ([]Query, error) {
 	c.depwarn("GetQueriesByLevelID", "GetAuditQueriesByLevelID")
 	c.logger.Debugf("Get all queries for %v", level)
@@ -158,49 +113,7 @@ func (c Cx1Client) GetQueriesByLevelID(level, levelId string) ([]Query, error) {
 	return queries, nil
 }
 
-/*
-func FindQueryByName(queries []AuditQuery, level, language, group, name string) (AuditQuery, error) {
-	for _, q := range queries {
-		if q.Level == level && q.Language == language && q.Group == group && q.Name == name {
-			return q, nil
-		}
-	}
-
-	return AuditQuery{}, fmt.Errorf("no query found matching [%v] %v -> %v -> %v", level, language, group, name)
-}
-
-func (c Cx1Client) DeleteQuery(query AuditQuery) error {
-	return c.DeleteQueryByName(query.Level, query.LevelID, query.Language, query.Group, query.Name)
-}
-
-func (c Cx1Client) DeleteQueryByName(level, levelID, language, group, query string) error {
-	c.depwarn("DeleteQueryByName", "DeleteAuditQueryByName")
-	c.logger.Debugf("Delete %v query by name: %v -> %v -> %v", level, language, group, query)
-	path := fmt.Sprintf("queries%%2F%v%%2F%v%%2F%v%%2F%v", language, group, query, query)
-
-	_, err := c.sendRequest(http.MethodDelete, fmt.Sprintf("/cx-audit/queries/%v/%v.cs", levelID, path), nil, nil)
-	if err != nil {
-		// currently there's a bug where the response can be error 500 even if it succeeded.
-
-		q, err2 := c.GetQueryByName(levelID, language, group, query)
-		if err2 != nil {
-			c.logger.Warnf("error while deleting query (%s) followed by error while checking if the query was deleted (%s) - assuming the query was deleted", err, err2)
-			return nil
-		}
-
-		if q.Level != level {
-			c.logger.Warnf("While deleting the query an error was returned (%s) but the query was deleted", err)
-			return nil
-		} else {
-			return fmt.Errorf("error while deleting query (%s) and the query %v still exists", err, q)
-		}
-	}
-
-	return nil
-} */
-
 func (c Cx1Client) GetQueries() (QueryCollection, error) {
-	c.depwarn("GetQueries", "GetAuditQueries")
 	var qc QueryCollection
 	q, err := c.GetPresetQueries()
 	if err != nil {

--- a/reports.go
+++ b/reports.go
@@ -9,10 +9,6 @@ import (
 )
 
 // Reports
-func (c Cx1Client) RequestNewReport(scanID, projectID, branch, reportType string) (string, error) {
-	c.depwarn("RequestNewReport", "RequestNewReportByID")
-	return c.RequestNewReportByID(scanID, projectID, branch, reportType)
-}
 
 func (c Cx1Client) RequestNewReportByID(scanID, projectID, branch, reportType string) (string, error) {
 	jsonData := map[string]interface{}{
@@ -49,10 +45,6 @@ func (c Cx1Client) RequestNewReportByID(scanID, projectID, branch, reportType st
 	err = json.Unmarshal([]byte(data), &reportResponse)
 
 	return reportResponse.ReportId, err
-}
-func (c Cx1Client) GetReportStatus(reportID string) (ReportStatus, error) {
-	c.depwarn("GetReportStatus", "GetReportStatusByID")
-	return c.GetReportStatusByID(reportID)
 }
 
 func (c Cx1Client) GetReportStatusByID(reportID string) (ReportStatus, error) {

--- a/results.go
+++ b/results.go
@@ -9,10 +9,6 @@ import (
 	"strings"
 )
 
-func (c Cx1Client) GetScanResults(scanID string, limit uint64) (ScanResultSet, error) {
-	c.depwarn("GetScanResults", "GetScanResultsByID")
-	return c.GetScanResultsByID(scanID, limit)
-}
 func (c Cx1Client) GetScanResultsByID(scanID string, limit uint64) (ScanResultSet, error) {
 	c.logger.Debug("Get Cx1 Scan Results for scan %v", scanID)
 	var resultResponse struct {
@@ -95,11 +91,6 @@ func (c Cx1Client) GetScanResultsByID(scanID string, limit uint64) (ScanResultSe
 	return ResultSet, nil
 }
 
-func (c Cx1Client) GetScanResultsCount(scanID string) (uint64, error) {
-	c.depwarn("GetScanResultsCount", "GetScanResultsCountByID")
-	return c.GetScanResultsCountByID(scanID)
-}
-
 func (c Cx1Client) GetScanResultsCountByID(scanID string) (uint64, error) {
 	c.logger.Debugf("Get Cx1 Scan Results count for scan %v", scanID)
 	var resultResponse struct {
@@ -151,11 +142,6 @@ func (r ScanKICSResult) CreateResultsPredicate(projectId string) KICSResultsPred
 }
 
 // results
-func (c Cx1Client) AddResultsPredicates(predicates []SASTResultsPredicates) error {
-	c.depwarn("AddResultsPredicates", "AddSASTResultsPredicates")
-	return c.AddSASTResultsPredicates(predicates)
-}
-
 func (c Cx1Client) AddSASTResultsPredicates(predicates []SASTResultsPredicates) error {
 	c.logger.Debugf("Adding %d SAST results predicates", len(predicates))
 
@@ -179,11 +165,6 @@ func (c Cx1Client) AddKICSResultsPredicates(predicates []KICSResultsPredicates) 
 
 	_, err = c.sendRequest(http.MethodPost, "/kics-results-predicates", bytes.NewReader(jsonBody), nil)
 	return err
-}
-
-func (c Cx1Client) GetResultsPredicatesByID(SimilarityID string, ProjectID string) ([]SASTResultsPredicates, error) {
-	c.depwarn("GetResultsPredicatesByID", "GetSASTResultsPredicatesByID")
-	return c.GetSASTResultsPredicatesByID(SimilarityID, ProjectID)
 }
 
 func (c Cx1Client) GetSASTResultsPredicatesByID(SimilarityID string, ProjectID string) ([]SASTResultsPredicates, error) {

--- a/roles.go
+++ b/roles.go
@@ -31,11 +31,6 @@ func (r *Role) HasRole(name string) bool {
 	return false
 }
 
-func (c Cx1Client) GetKeyCloakRoles() ([]Role, error) {
-	c.depwarn("*KeyCloakRoles*", "*IAMRoles*")
-	return c.GetIAMRoles()
-}
-
 func (c Cx1Client) GetIAMRoles() ([]Role, error) {
 	c.logger.Debugf("Getting KeyCloak Roles")
 	var roles []Role
@@ -50,10 +45,6 @@ func (c Cx1Client) GetIAMRoles() ([]Role, error) {
 	return roles, err
 }
 
-func (c Cx1Client) GetKeyCloakRoleByName(name string) (Role, error) {
-	c.depwarn("*KeyCloakRoles*", "*IAMRoles*")
-	return c.GetIAMRoleByName(name)
-}
 func (c Cx1Client) GetIAMRoleByName(name string) (Role, error) {
 	c.logger.Debugf("Getting KeyCloak Role named %v", name)
 	var role Role
@@ -64,11 +55,6 @@ func (c Cx1Client) GetIAMRoleByName(name string) (Role, error) {
 
 	err = json.Unmarshal(response, &role)
 	return role, err
-}
-
-func (c Cx1Client) GetRolesByClient(clientId string) ([]Role, error) {
-	c.depwarn("GetRolesByClient", "GetRolesByClientID")
-	return c.GetRolesByClientID(clientId)
 }
 
 func (c Cx1Client) GetRolesByClientID(clientId string) ([]Role, error) {
@@ -83,11 +69,6 @@ func (c Cx1Client) GetRolesByClientID(clientId string) ([]Role, error) {
 	err = json.Unmarshal(response, &roles)
 	c.logger.Tracef("Got %d roles", len(roles))
 	return roles, err
-}
-
-func (c Cx1Client) GetRoleByClientAndName(clientId string, name string) (Role, error) {
-	c.depwarn("GetRoleByClientAndName", "GetRoleByClientIDAndName")
-	return c.GetRoleByClientIDAndName(clientId, name)
 }
 
 func (c Cx1Client) GetRoleByClientIDAndName(clientId string, name string) (Role, error) {
@@ -157,11 +138,6 @@ func (c Cx1Client) RemoveRoleComposites(role *Role, roles *[]Role) error {
 	return nil
 }
 
-func (c Cx1Client) CreateASTRole(roleName, createdBy string) (Role, error) {
-	c.depwarn("CreateASTRole", "CreateAppRole")
-	return c.CreateAppRole(roleName, createdBy)
-}
-
 func (c Cx1Client) CreateAppRole(roleName, createdBy string) (Role, error) {
 	c.logger.Debugf("User %v creating client role %v", createdBy, roleName)
 	data := map[string]interface{}{
@@ -205,11 +181,6 @@ func (c Cx1Client) DeleteRoleByID(roleId string) error {
 	return err
 }
 
-func (c Cx1Client) GetASTRoles() ([]Role, error) {
-	c.depwarn("GetASTRoles", "GetAppRoles")
-	return c.GetAppRoles()
-}
-
 func (c Cx1Client) GetAppRoles() ([]Role, error) {
 	c.logger.Debug("Getting roles set for ast-app client")
 	return c.GetRolesByClientID(c.GetASTAppID())
@@ -219,18 +190,8 @@ func (c Cx1Client) GetAppRoleByName(name string) (Role, error) {
 	c.logger.Debugf("Getting role named %v in ast-app client", name)
 	return c.GetRoleByClientIDAndName(c.GetASTAppID(), name)
 }
-func (c Cx1Client) GetASTRoleByName(name string) (Role, error) {
-	c.depwarn("GetASTRoleByName", "GetAppRoleByName")
-	c.logger.Debugf("Getting role named %v in ast-app client", name)
-	return c.GetRoleByClientIDAndName(c.GetASTAppID(), name)
-}
 
 // convenience function to get both KeyCloak (system) roles plus the AST-APP-specific roles
-func (c Cx1Client) GetCombinedRoles() ([]Role, error) {
-	c.depwarn("GetCombinedRoles*", "GetRoles*")
-	return c.GetRoles()
-}
-
 func (c Cx1Client) GetRoles() ([]Role, error) {
 	c.logger.Debug("Getting all available roles")
 	ast_roles, err := c.GetAppRoles()
@@ -244,11 +205,6 @@ func (c Cx1Client) GetRoles() ([]Role, error) {
 
 	ast_roles = append(ast_roles, system_roles...)
 	return ast_roles, nil
-}
-
-func (c Cx1Client) GetCombinedRoleByName(name string) (Role, error) {
-	c.depwarn("GetCombinedRoleByName", "GetRoleByName")
-	return c.GetRoleByName(name)
 }
 
 func (c Cx1Client) GetRoleByName(name string) (Role, error) {

--- a/scans.go
+++ b/scans.go
@@ -12,11 +12,6 @@ import (
 	"time"
 )
 
-func (c Cx1Client) GetScan(scanID string) (Scan, error) {
-	c.depwarn("GetScan", "GetScanByID")
-	return c.GetScanByID(scanID)
-}
-
 func (c Cx1Client) GetScanByID(scanID string) (Scan, error) {
 	var scan Scan
 
@@ -52,11 +47,6 @@ func (c Cx1Client) CancelScanByID(scanID string) error {
 	}
 
 	return nil
-}
-
-func (c Cx1Client) GetScanMetadata(scanID string) (ScanMetadata, error) {
-	c.depwarn("GetScanMetadata", "GetScanMetadataByID")
-	return c.GetScanMetadataByID(scanID)
 }
 
 func (c Cx1Client) GetScanMetadataByID(scanID string) (ScanMetadata, error) {
@@ -206,10 +196,6 @@ func (c Cx1Client) GetScanSummariesByID(scanIDs []string) ([]ScanSummary, error)
 	return ScansSummaries.ScanSum, nil
 }
 
-func (c Cx1Client) GetScanLogs(scanID, engine string) ([]byte, error) {
-	c.depwarn("GetScanLogs", "GetScanLogsByID")
-	return c.GetScanLogsByID(scanID, engine)
-}
 func (c Cx1Client) GetScanLogsByID(scanID, engine string) ([]byte, error) {
 	c.logger.Debugf("Fetching scan logs for scan %v", scanID)
 
@@ -265,11 +251,6 @@ func (c Cx1Client) scanProject(scanConfig map[string]interface{}) (Scan, error) 
 	return scan, err
 }
 
-func (c Cx1Client) ScanProjectZip(projectID, sourceUrl, branch string, settings []ScanConfiguration, tags map[string]string) (Scan, error) {
-	c.depwarn("ScanProjectZip", "ScanProjectZipByID")
-	return c.ScanProjectZipByID(projectID, sourceUrl, branch, settings, tags)
-}
-
 func (c Cx1Client) ScanProjectZipByID(projectID, sourceUrl, branch string, settings []ScanConfiguration, tags map[string]string) (Scan, error) {
 	jsonBody := map[string]interface{}{
 		"project": map[string]interface{}{"id": projectID},
@@ -287,11 +268,6 @@ func (c Cx1Client) ScanProjectZipByID(projectID, sourceUrl, branch string, setti
 		return scan, fmt.Errorf("failed to start a zip scan for project %v: %s", projectID, err)
 	}
 	return scan, err
-}
-
-func (c Cx1Client) ScanProjectGit(projectID, repoUrl, branch string, settings []ScanConfiguration, tags map[string]string) (Scan, error) {
-	c.depwarn("ScanProjectGit", "ScanProjectGitByID")
-	return c.ScanProjectGitByID(projectID, repoUrl, branch, settings, tags)
 }
 
 func (c Cx1Client) ScanProjectGitByID(projectID, repoUrl, branch string, settings []ScanConfiguration, tags map[string]string) (Scan, error) {
@@ -314,11 +290,6 @@ func (c Cx1Client) ScanProjectGitByID(projectID, repoUrl, branch string, setting
 }
 
 // convenience function
-func (c Cx1Client) ScanProject(projectID, sourceUrl, branch, scanType string, settings []ScanConfiguration, tags map[string]string) (Scan, error) {
-	c.depwarn("ScanProject", "ScanProjectByID")
-	return c.ScanProjectByID(projectID, sourceUrl, branch, scanType, settings, tags)
-}
-
 func (c Cx1Client) ScanProjectByID(projectID, sourceUrl, branch, scanType string, settings []ScanConfiguration, tags map[string]string) (Scan, error) {
 	if scanType == "upload" {
 		return c.ScanProjectZipByID(projectID, sourceUrl, branch, settings, tags)

--- a/users.go
+++ b/users.go
@@ -292,11 +292,6 @@ func (c Cx1Client) GetUserGroups(user *User) ([]Group, error) {
 	return user.Groups, nil
 }
 
-func (c Cx1Client) AssignUserToGroup(user *User, groupId string) error {
-	c.depwarn("AssignUserToGroup", "AssignUserToGroupByID")
-	return c.AssignUserToGroupByID(user, groupId)
-}
-
 func (c Cx1Client) AssignUserToGroupByID(user *User, groupId string) error {
 	inGroup, err := user.IsInGroupByID(groupId)
 	if err != nil {
@@ -331,11 +326,6 @@ func (c Cx1Client) AssignUserToGroupByID(user *User, groupId string) error {
 		user.Groups = append(user.Groups, group)
 	}
 	return nil
-}
-
-func (c Cx1Client) RemoveUserFromGroup(user *User, groupId string) error {
-	c.depwarn("RemoveUserFromGroup", "RemoveUserFromGroupByID")
-	return c.RemoveUserFromGroupByID(user, groupId)
 }
 
 func (c Cx1Client) RemoveUserFromGroupByID(user *User, groupId string) error {
@@ -587,36 +577,3 @@ func (c Cx1Client) removeUserKCRoles(userID string, roles *[]Role) error {
 	_, err = c.sendRequestIAM(http.MethodDelete, "/auth/admin", fmt.Sprintf("/users/%v/role-mappings/realm", userID), bytes.NewReader(jsonBody), nil)
 	return err
 }
-
-// these functions to be deprecated/hidden in favor of simpler functions below
-func (c Cx1Client) GetUserRoleMappings(userID string, clientID string) ([]Role, error) {
-	c.depwarn("*UserRoleMappings*", "*UserRoles*")
-	return c.getUserRolesByClientID(userID, clientID)
-}
-
-func (c Cx1Client) GetUserASTRoleMappings(userID string) ([]Role, error) {
-	c.depwarn("*UserRoleMappings*", "*UserRoles*")
-	return c.getUserRolesByClientID(userID, c.GetASTAppID())
-}
-
-func (c Cx1Client) AddUserRoleMappings(userID string, clientID string, roles []Role) error {
-	c.depwarn("*UserRoleMappings*", "*UserRoles*")
-	return c.addUserRolesByClientID(userID, clientID, &roles)
-}
-
-func (c Cx1Client) AddUserASTRoleMappings(userID string, roles []Role) error {
-	c.depwarn("*UserRoleMappings*", "*UserRoles*")
-	return c.addUserRolesByClientID(userID, c.GetASTAppID(), &roles)
-}
-
-func (c Cx1Client) RemoveUserRoleMappings(userID string, clientID string, roles []Role) error {
-	c.depwarn("*UserRoleMappings*", "*UserRoles*")
-	return c.removeUserRolesByClientID(userID, clientID, &roles)
-}
-
-func (c Cx1Client) RemoveUserASTRoleMappings(userID string, roles []Role) error {
-	c.depwarn("*UserRoleMappings*", "*UserRoles*")
-	return c.removeUserRolesByClientID(userID, c.GetASTAppID(), &roles)
-}
-
-// end to-be-deprecated function block


### PR DESCRIPTION
Removing some old functions that were meant to be deprecated.
Added a convenience function "NewClient" which will use flag.Parse to pick up the standard parameters for creating a client (Cx1/IAM URLs, tenant, apikey, and client id+secret)