### PR TITLE
Pagination

### DIFF
--- a/_examples/ListScans/go.mod
+++ b/_examples/ListScans/go.mod
@@ -11,6 +11,7 @@ require (
 require (
 	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/google/go-querystring v1.1.0 // indirect
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
 	golang.org/x/oauth2 v0.13.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect
@@ -18,6 +19,4 @@ require (
 	google.golang.org/protobuf v1.31.0 // indirect
 )
 
-replace (
-	github.com/cxpsemea/Cx1ClientGo => ../../
-)
+replace github.com/cxpsemea/Cx1ClientGo => ../../

--- a/_examples/ListScans/go.sum
+++ b/_examples/ListScans/go.sum
@@ -1,5 +1,3 @@
-github.com/cxpsemea/Cx1ClientGo v0.0.75 h1:XuJstazIJjaltCihd9qkCm0o9m8UUaOGTRg8IMsazvI=
-github.com/cxpsemea/Cx1ClientGo v0.0.75/go.mod h1:ZwnGbjc37SzyVc74gnDYCDO5UGkWnQ9R+rBBbxeOWTg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -9,9 +7,12 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
+github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/applications.go
+++ b/applications.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+
+	"github.com/google/go-querystring/query"
 )
 
 // Get the first count Applications
@@ -76,7 +78,7 @@ func (c Cx1Client) GetApplicationByName(name string) (Application, error) {
 // Returns the number of applications matching the filter and the array of matching applications
 // with one page (filter.Offset to filter.Offset+filter.Limit) of results
 func (c Cx1Client) GetApplicationsFiltered(filter ApplicationFilter) (uint64, []Application, error) {
-	params := filter.UrlParams()
+	params, _ := query.Values(filter)
 
 	var ApplicationResponse struct {
 		BaseFilteredResponse
@@ -194,7 +196,8 @@ func (c Cx1Client) GetApplicationCountByName(name string) (uint64, error) {
 
 func (c Cx1Client) GetApplicationCountFiltered(filter ApplicationFilter) (uint64, error) {
 	filter.Limit = 1
-	c.logger.Debugf("Get Cx1 Application count matching filter: %v", filter.UrlParams().Encode())
+	params, _ := query.Values(filter)
+	c.logger.Debugf("Get Cx1 Application count matching filter: %v", params.Encode())
 
 	count, _, err := c.GetApplicationsFiltered(filter)
 

--- a/cx1cache.go
+++ b/cx1cache.go
@@ -52,7 +52,7 @@ func (c *Cx1Cache) RefreshProjects(client *Cx1Client) error {
 	var err error
 	if !c.ProjectRefresh {
 		c.ProjectRefresh = true
-		c.Projects, err = client.GetProjects()
+		c.Projects, err = client.GetAllProjects()
 		c.ProjectRefresh = false
 	}
 	return err
@@ -63,7 +63,7 @@ func (c *Cx1Cache) RefreshApplications(client *Cx1Client) error {
 	var err error
 	if !c.ApplicationRefresh {
 		c.ApplicationRefresh = true
-		c.Applications, err = client.GetApplications()
+		c.Applications, err = client.GetAllApplications()
 		c.ApplicationRefresh = false
 	}
 	return err
@@ -96,7 +96,7 @@ func (c *Cx1Cache) RefreshUsers(client *Cx1Client) error {
 	var err error
 	if !c.UserRefresh {
 		c.UserRefresh = true
-		c.Users, err = client.GetUsers()
+		c.Users, err = client.GetAllUsers()
 		c.UserRefresh = false
 	}
 	return err

--- a/cx1cache.go
+++ b/cx1cache.go
@@ -52,7 +52,7 @@ func (c *Cx1Cache) RefreshProjects(client *Cx1Client) error {
 	var err error
 	if !c.ProjectRefresh {
 		c.ProjectRefresh = true
-		c.Projects, err = client.GetProjects(0)
+		c.Projects, err = client.GetProjects()
 		c.ProjectRefresh = false
 	}
 	return err
@@ -63,7 +63,7 @@ func (c *Cx1Cache) RefreshApplications(client *Cx1Client) error {
 	var err error
 	if !c.ApplicationRefresh {
 		c.ApplicationRefresh = true
-		c.Applications, err = client.GetApplications(0)
+		c.Applications, err = client.GetApplications()
 		c.ApplicationRefresh = false
 	}
 	return err

--- a/cx1client.go
+++ b/cx1client.go
@@ -306,26 +306,8 @@ func (c *Cx1Client) InitializeClient() error {
 		c.logger.Warnf("Failed to get tenant flags: %s", err)
 	}
 
-	c.consts.MigrationPollingMaxSeconds = 300 // 5 min
-	c.consts.MigrationPollingDelaySeconds = 30
-
-	c.consts.AuditEnginePollingMaxSeconds = 300 // 5 min
-	c.consts.AuditEnginePollingDelaySeconds = 30
-
-	c.consts.AuditScanPollingMaxSeconds = 600 // 10 min
-	c.consts.AuditScanPollingDelaySeconds = 30
-
-	c.consts.AuditCompilePollingMaxSeconds = 600 // 10 min
-	c.consts.AuditCompilePollingDelaySeconds = 30
-
-	c.consts.AuditLanguagePollingMaxSeconds = 300 // 5 min
-	c.consts.AuditLanguagePollingDelaySeconds = 30
-
-	c.consts.ScanPollingMaxSeconds = 0
-	c.consts.ScanPollingDelaySeconds = 30
-
-	c.consts.ProjectApplicationLinkPollingDelaySeconds = 5
-	c.consts.ProjectApplicationLinkPollingMaxSeconds = 300 // 5 min
+	c.InitializeClientVars()
+	c.InitializePaginationSettings()
 
 	return nil
 }
@@ -398,15 +380,6 @@ func (c Cx1Client) CheckFlag(flag string) (bool, error) {
 	}
 
 	return setting, nil
-}
-
-func (c Cx1Client) GetClientVars() ClientVars {
-	c.logger.Debug("Retrieving client vars - polling limits set in seconds")
-	return c.consts
-}
-
-func (c *Cx1Client) SetClientVars(clientvars ClientVars) {
-	c.consts = clientvars
 }
 
 func (c Cx1Client) GetTenantOwner() (TenantOwner, error) {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/golang-jwt/jwt/v4 v4.5.0
+	github.com/google/go-querystring v1.1.0
 	github.com/sirupsen/logrus v1.9.3
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d
 	golang.org/x/oauth2 v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,11 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
+github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=

--- a/groups.go
+++ b/groups.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/google/go-querystring/query"
 )
 
 func (g *Group) String() string {
@@ -190,7 +192,7 @@ func (c Cx1Client) GetGroupCount(search string, topLevel bool) (uint64, error) {
 // Returns the number of applications matching the filter and the array of matching applications
 func (c Cx1Client) GetGroupsFiltered(filter GroupFilter, fill bool) ([]Group, error) {
 	var groups []Group
-	params := filter.UrlParams()
+	params, _ := query.Values(filter)
 
 	response, err := c.sendRequestIAM(http.MethodGet, "/auth/admin", fmt.Sprintf("/groups?%v", params.Encode()), nil, nil)
 	if err != nil {

--- a/groups.go
+++ b/groups.go
@@ -109,6 +109,10 @@ func (c Cx1Client) GetGroups() ([]Group, error) {
 	return groups, err
 }
 
+func (c Cx1Client) GetAllGroups() ([]Group, error) {
+	return c.GetGroups()
+}
+
 // will return the first group matching 'groupname'
 // the group is not "filled": the subgroups array will be empty (use FillGroup/GetGroupChildren)
 func (c Cx1Client) GetGroupByName(groupname string) (Group, error) {
@@ -227,19 +231,6 @@ func (c Cx1Client) GetAllGroupsFiltered(filter GroupFilter, fill bool) (uint64, 
 
 	return count, groups, err
 }
-
-/*
-func (f GroupFilter) UrlParams() url.Values {
-	params := url.Values{}
-	params.Add("first", strconv.FormatUint(f.First, 10))
-	params.Add("max", strconv.FormatUint(f.Max, 10))
-	if f.Search != "" {
-		params.Add("search", f.Search)
-	}
-
-	return params
-}
-*/
 
 func (c Cx1Client) DeleteGroup(group *Group) error {
 	c.logger.Debugf("Deleting Group %v...", group.String())

--- a/misc.go
+++ b/misc.go
@@ -1,0 +1,75 @@
+package Cx1ClientGo
+
+import (
+	"net/url"
+
+	"github.com/google/go-querystring/query"
+)
+
+// miscellaneous functions (ClientVars & Pagination)
+
+func (c Cx1Client) GetClientVars() ClientVars {
+	return c.consts
+}
+
+func (c *Cx1Client) SetClientVars(clientvars ClientVars) {
+	c.consts = clientvars
+}
+
+func (c *Cx1Client) InitializeClientVars() {
+	c.consts = ClientVars{
+		MigrationPollingMaxSeconds:                300, // 5 min
+		MigrationPollingDelaySeconds:              30,
+		AuditEnginePollingMaxSeconds:              300,
+		AuditEnginePollingDelaySeconds:            30,
+		AuditScanPollingMaxSeconds:                600,
+		AuditScanPollingDelaySeconds:              30,
+		AuditCompilePollingMaxSeconds:             600,
+		AuditCompilePollingDelaySeconds:           30,
+		AuditLanguagePollingMaxSeconds:            300,
+		AuditLanguagePollingDelaySeconds:          30,
+		ScanPollingMaxSeconds:                     0,
+		ScanPollingDelaySeconds:                   30,
+		ProjectApplicationLinkPollingMaxSeconds:   300,
+		ProjectApplicationLinkPollingDelaySeconds: 15,
+	}
+}
+
+func (c Cx1Client) GetPaginationSettings() PaginationSettings {
+	c.logger.Debug("Retrieving client vars - polling limits set in seconds")
+	return c.pagination
+}
+
+func (c *Cx1Client) SetPaginationSettings(pagination PaginationSettings) {
+	c.pagination = pagination
+}
+
+func (c *Cx1Client) InitializePaginationSettings() {
+	c.pagination = PaginationSettings{
+		Applications: 20,
+		Branches:     20,
+		Groups:       50,
+		Projects:     20,
+		Results:      20,
+		Scans:        20,
+		Users:        50,
+	}
+}
+
+func (f *BaseFilter) Bump() {
+	f.Offset += f.Limit
+}
+
+func (f BaseFilter) UrlParams() url.Values {
+	params, _ := query.Values(f)
+	return params
+}
+
+func (f *BaseIAMFilter) Bump() {
+	f.First += f.Max
+}
+
+func (f BaseIAMFilter) UrlParams() url.Values {
+	params, _ := query.Values(f)
+	return params
+}

--- a/misc.go
+++ b/misc.go
@@ -44,7 +44,7 @@ func (c *Cx1Client) InitializePaginationSettings() {
 		Branches:     20,
 		Groups:       50,
 		Projects:     20,
-		Results:      20,
+		Results:      50,
 		Scans:        20,
 		Users:        50,
 	}

--- a/misc.go
+++ b/misc.go
@@ -1,11 +1,5 @@
 package Cx1ClientGo
 
-import (
-	"net/url"
-
-	"github.com/google/go-querystring/query"
-)
-
 // miscellaneous functions (ClientVars & Pagination)
 
 func (c Cx1Client) GetClientVars() ClientVars {
@@ -60,16 +54,6 @@ func (f *BaseFilter) Bump() {
 	f.Offset += f.Limit
 }
 
-func (f BaseFilter) UrlParams() url.Values {
-	params, _ := query.Values(f)
-	return params
-}
-
 func (f *BaseIAMFilter) Bump() {
 	f.First += f.Max
-}
-
-func (f BaseIAMFilter) UrlParams() url.Values {
-	params, _ := query.Values(f)
-	return params
 }

--- a/projects.go
+++ b/projects.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/google/go-querystring/query"
 	"golang.org/x/exp/slices"
 )
 
@@ -214,7 +215,7 @@ func (c Cx1Client) GetProjectsByNameAndGroupID(projectName string, groupID strin
 // Returns the total number of matching results plus an array of projects with
 // one page of results (from filter.Offset to filter.Offset+filter.Limit)
 func (c Cx1Client) GetProjectsFiltered(filter ProjectFilter) (uint64, []Project, error) {
-	params := filter.UrlParams()
+	params, _ := query.Values(filter)
 
 	var ProjectResponse struct {
 		BaseFilteredResponse
@@ -348,7 +349,7 @@ func (c Cx1Client) GetProjectBranchesByID(projectID string) ([]string, error) {
 
 // retrieves a page (filter.Offset to filter.Offset+filter.Limit) of branches for a project
 func (c Cx1Client) GetProjectBranchesFiltered(filter ProjectBranchFilter) ([]string, error) {
-	params := filter.UrlParams()
+	params, _ := query.Values(filter)
 	branches := []string{}
 
 	data, err := c.sendRequest(http.MethodGet, fmt.Sprintf("/projects/branches?%v", params.Encode()), nil, nil)
@@ -415,7 +416,7 @@ func (c Cx1Client) GetProjectCountByName(name string) (uint64, error) {
 }
 
 func (c Cx1Client) GetProjectCountFiltered(filter ProjectFilter) (uint64, error) {
-	params := filter.UrlParams()
+	params, _ := query.Values(filter)
 	filter.Limit = 1
 	c.logger.Debugf("Get Cx1 Project count matching filter: %v", params.Encode())
 	count, _, err := c.GetProjectsFiltered(filter)

--- a/results.go
+++ b/results.go
@@ -5,64 +5,49 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
 	"strings"
+
+	"github.com/google/go-querystring/query"
 )
 
 func (c Cx1Client) GetScanResultsByID(scanID string, limit uint64) (ScanResultSet, error) {
-	c.logger.Debugf("Get Cx1 Scan Results for scan %v", scanID)
+	c.logger.Debugf("Get %d Cx1 Scan Results for scan %v", limit, scanID)
 
-	params := url.Values{
-		"scan-id":  {scanID},
-		"limit":    {fmt.Sprintf("%d", limit)},
-		"state":    []string{},
-		"severity": []string{},
-		"status":   []string{},
-	}
+	_, results, err := c.GetXScanResultsFiltered(ScanResultsFilter{
+		BaseFilter: BaseFilter{Limit: c.pagination.Results},
+		ScanID:     scanID,
+	}, limit)
 
-	response, err := c.sendRequest(http.MethodGet, fmt.Sprintf("/results/?%v", params.Encode()), nil, nil)
-	if err != nil && len(response) == 0 {
-		c.logger.Tracef("Failed to retrieve scan results for scan ID %v", scanID)
-		return ScanResultSet{}, err
-	}
+	return results, err
+}
 
-	_, results, err := c.parseScanResults(response)
+func (c Cx1Client) GetAllScanResultsByID(scanID string) (ScanResultSet, error) {
+	c.logger.Debugf("Get all Cx1 Scan Results for scan %v", scanID)
+
+	_, results, err := c.GetAllScanResultsFiltered(ScanResultsFilter{
+		BaseFilter: BaseFilter{Limit: c.pagination.Results},
+		ScanID:     scanID,
+	})
 
 	return results, err
 }
 
 func (c Cx1Client) GetScanResultsCountByID(scanID string) (uint64, error) {
 	c.logger.Debugf("Get Cx1 Scan Results count for scan %v", scanID)
-	var resultResponse struct {
-		//Results    []ScanResult
-		TotalCount uint64
-	}
+	count, _, err := c.GetScanResultsFiltered(ScanResultsFilter{
+		BaseFilter: BaseFilter{Limit: 0},
+		ScanID:     scanID,
+	})
 
-	params := url.Values{
-		"scan-id":  {scanID},
-		"limit":    {fmt.Sprintf("%d", 0)},
-		"state":    []string{},
-		"severity": []string{},
-		"status":   []string{},
-	}
-
-	response, err := c.sendRequest(http.MethodGet, fmt.Sprintf("/results/?%v", params.Encode()), nil, nil)
-	if err != nil && len(response) == 0 {
-		c.logger.Tracef("Failed to retrieve scan results for scan ID %v", scanID)
-		return 0, err
-	}
-
-	err = json.Unmarshal(response, &resultResponse)
-	if err != nil {
-		c.logger.Tracef("Failed while parsing response: %s", err)
-		c.logger.Tracef("Response contents: %s", string(response))
-		return 0, err
-	}
-	return resultResponse.TotalCount, nil
+	return count, err
 }
 
+// returns one 'page' of scan results matching the filter
+// returns items (filter.Offset*filter.Limit) to (filter.Offset + 1)*filter.Limit
+// returns the count of items retrieved, however some items may not be parsed into the result
+// set depending on support in cx1clientgo
 func (c Cx1Client) GetScanResultsFiltered(filter ScanResultsFilter) (uint64, ScanResultSet, error) {
-	params := filter.UrlParams()
+	params, _ := query.Values(filter)
 
 	results := ScanResultSet{}
 
@@ -77,32 +62,37 @@ func (c Cx1Client) GetScanResultsFiltered(filter ScanResultsFilter) (uint64, Sca
 	return count, results, err
 }
 
+func (s *ScanResultsFilter) Bump() { // this one does offset in pages rather than items
+	s.Offset++
+}
+
+// gets all of the results available matching a filter
+// the counter returned represents the total number of results which were parsed
+// this may not include some of the returned results depending on Cx1ClientGo support
 func (c Cx1Client) GetAllScanResultsFiltered(filter ScanResultsFilter) (uint64, ScanResultSet, error) {
 	var results ScanResultSet
-
-	summary, err := c.GetScanSummaryFiltered(filter)
 
 	count, rs, err := c.GetScanResultsFiltered(filter)
 	results = rs
 
-	for err == nil && count > filter.Offset+filter.Limit && filter.Limit > 0 {
+	for err == nil && count > (filter.Offset+1)*filter.Limit && filter.Limit > 0 {
 		filter.Bump()
 		_, rs, err = c.GetScanResultsFiltered(filter)
 		results.Append(&rs)
 	}
 
-	return count, results, err
+	return rs.Count(), results, err
 }
 
 // will return at least X results matching the filter
 // May return more due to paging eg: requesting 101 with a 100-item page can return 200 results
-func (c Cx1Client) GetXResultsFiltered(filter ScanResultsFilter, count uint64) (uint64, ScanResultSet, error) {
+func (c Cx1Client) GetXScanResultsFiltered(filter ScanResultsFilter, desiredcount uint64) (uint64, ScanResultSet, error) {
 	var results ScanResultSet
 
 	_, rs, err := c.GetScanResultsFiltered(filter)
 	results = rs
 
-	for err == nil && count > filter.Offset+filter.Limit && filter.Limit > 0 {
+	for err == nil && desiredcount > (filter.Offset+1)*filter.Limit && filter.Limit > 0 {
 		filter.Bump()
 		_, rs, err = c.GetScanResultsFiltered(filter)
 		results.Append(&rs)
@@ -239,6 +229,12 @@ func (r ScanKICSResult) String() string {
 func (r ScanSCAResult) String() string {
 	return fmt.Sprintf("%v - %v (%v) - recommended version %v: %v", r.Data.PackageIdentifier, r.Data.PublishedAt, r.SimilarityID, r.Data.RecommendedVersion, r.Data.GetType("Advisory").URL)
 }
+func (r ScanSCAContainerResult) String() string {
+	return fmt.Sprintf("%v %v - %v (%v)", r.Data.PackageName, r.Data.PackageVersion, r.Data.PublishedAt, r.SimilarityID)
+}
+func (r ScanContainersResult) String() string {
+	return fmt.Sprintf("%v %v / %v #%v (%v)", r.Data.PackageName, r.Data.PackageVersion, r.Data.ImageName, r.Data.ImageTag, r.SimilarityID)
+}
 
 func (r ScanSCAResultData) GetType(packageDataType string) ScanSCAResultPackageData {
 	for _, p := range r.PackageData {
@@ -286,11 +282,11 @@ func (c Cx1Client) GetScanSASTResultSummary(results *ScanResultSet) ScanResultSu
 }
 
 func (s ScanResultSet) String() string {
-	return fmt.Sprintf("Result set with %d SAST, %d SCA, %d SCAContainer, and %d KICS results", len(s.SAST), len(s.SCA), len(s.SCAContainer), len(s.KICS))
+	return fmt.Sprintf("Result set with %d SAST, %d SCA, %d SCAContainer, %d KICS, and %d Containers results", len(s.SAST), len(s.SCA), len(s.SCAContainer), len(s.KICS), len(s.Containers))
 }
 
 func (s ScanResultSet) Count() uint64 {
-	return uint64(len(s.SAST) + len(s.SCA) + len(s.SCAContainer) + len(s.KICS))
+	return uint64(len(s.SAST) + len(s.SCA) + len(s.SCAContainer) + len(s.KICS) + len(s.Containers))
 }
 
 func (s *ScanResultSet) Append(results *ScanResultSet) {
@@ -305,6 +301,9 @@ func (s *ScanResultSet) Append(results *ScanResultSet) {
 	}
 	if len(results.SAST) > 0 {
 		s.SAST = append(s.SAST, results.SAST...)
+	}
+	if len(results.Containers) > 0 {
+		s.Containers = append(s.Containers, results.Containers...)
 	}
 }
 
@@ -325,6 +324,7 @@ func (s ScanResultSummary) String() string {
 			s.High.NotExploitable+s.Medium.NotExploitable+s.Low.NotExploitable+s.Information.NotExploitable))
 }
 
+// Note: response.TotalCount may be greater than the resultset, due to limited cx1clientgo engine support
 func (c Cx1Client) parseScanResults(response []byte) (uint64, ScanResultSet, error) {
 	var resultResponse struct {
 		Results    []map[string]interface{}
@@ -341,12 +341,14 @@ func (c Cx1Client) parseScanResults(response []byte) (uint64, ScanResultSet, err
 		c.logger.Tracef("Response contents: %s", string(response))
 		return resultResponse.TotalCount, ResultSet, err
 	}
-	c.logger.Debugf("Retrieved %d results", resultResponse.TotalCount)
+	//c.logger.Debugf("Retrieved %d results", resultResponse.TotalCount)
 
-	if uint64(len(resultResponse.Results)) != resultResponse.TotalCount {
-		c.logger.Warnf("Expected results total count %d but parsed only %d", resultResponse.TotalCount, len(resultResponse.Results))
-		c.logger.Tracef("Response was: %v", string(response))
-	}
+	/*
+		if uint64(len(resultResponse.Results)) != resultResponse.TotalCount {
+			c.logger.Warnf("Expected results total count %d but parsed only %d", resultResponse.TotalCount, len(resultResponse.Results))
+			c.logger.Tracef("Response was: %v", string(response))
+		}
+	*/
 
 	for _, r := range resultResponse.Results {
 		//c.logger.Infof("Result %v: %v", r["similarityId"].(string), r["type"].(string))
@@ -384,10 +386,20 @@ func (c Cx1Client) parseScanResults(response []byte) (uint64, ScanResultSet, err
 			} else {
 				ResultSet.SCAContainer = append(ResultSet.SCAContainer, SCACResult)
 			}
+		case "containers":
+			var ContainerResult ScanContainersResult
+			err := json.Unmarshal(jsonResult, &ContainerResult)
+			if err != nil {
+				c.logger.Warnf("Failed to unmarshal result %v to Containers type: %s", r["similarityId"].(string), err)
+			} else {
+				ResultSet.Containers = append(ResultSet.Containers, ContainerResult)
+			}
 		default:
 			c.logger.Warnf("Unable to unmarshal result %v of unknown type %v", r["similarityId"].(string), r["type"].(string))
 		}
 	}
+
+	c.logger.Debugf("Retrieved %d of %d results", ResultSet.Count(), resultResponse.TotalCount)
 
 	return resultResponse.TotalCount, ResultSet, nil
 }

--- a/types.go
+++ b/types.go
@@ -83,13 +83,13 @@ type PaginationSettings struct {
 }
 
 type BaseFilter struct {
-	Offset uint64 `url:"offset"`
-	Limit  uint64 `url:"limit"`
+	Offset uint64 `url:"offset"` // offset is set automatically for pagination
+	Limit  uint64 `url:"limit"`  // limit is set automatically for pagination, should generally not be 0
 }
 
 type BaseIAMFilter struct {
-	First uint64 `url:"first"`
-	Max   uint64 `url:"max"`
+	First uint64 `url:"first"` // offset is set automatically for pagination
+	Max   uint64 `url:"max"`   // limit is set automatically for pagination, should generally not be 0
 }
 
 type BaseFilteredResponse struct {
@@ -486,7 +486,7 @@ type Scan struct {
 type ScanFilter struct {
 	BaseFilter
 	ProjectID string    `url:"project-id"`
-	Sort      string    `url:"sort,omitempty"`
+	Sort      []string  `url:"sort,omitempty"` // Available values : -created_at, +created_at, -status, +status, +branch, -branch, +initiator, -initiator, +user_agent, -user_agent, +name, -name
 	TagKeys   []string  `url:"tags-keys,omitempty"`
 	TagValues []string  `url:"tags-values,omitempty"`
 	Statuses  []string  `url:"statuses,omitempty"`
@@ -515,6 +515,15 @@ type ScanResultSet struct {
 	SCA          []ScanSCAResult
 	SCAContainer []ScanSCAContainerResult
 	KICS         []ScanKICSResult
+}
+
+type ScanResultsFilter struct {
+	BaseFilter
+	Severity           []string `url:"severity"`
+	State              []string `url:"state"`
+	Status             []string `url:"status"`
+	ExcludeResultTypes []string `url:"exclude-result-types"` // Available values : DEV_AND_TEST, NONE
+	Sort               []string `url:"sort"`                 //Available values : -severity, +severity, -status, +status, -state, +state, -type, +type, -firstfoundat, +firstfoundat, -foundat, +foundat, -firstscanid, +firstscanid
 }
 
 // generic data common to all
@@ -667,37 +676,79 @@ type ScanSummary struct {
 	TenantID     string
 	ScanID       string
 	SASTCounters struct {
-		//QueriesCounters           []?
-		//SinkFileCounters          []?
-		LanguageCounters []struct {
-			Language string
-			Counter  uint64
-		}
-		ComplianceCounters []struct {
-			Compliance string
-			Counter    uint64
-		}
-		SeverityCounters []struct {
-			Severity string
-			Counter  uint64
-		}
-		StatusCounters []struct {
-			Status  string
-			Counter uint64
-		}
-		StateCounters []struct {
-			State   string
-			Counter uint64
-		}
-		TotalCounter        uint64
-		FilesScannedCounter uint64
+		QueriesCounters        []ScanSummaryQueriesCounter
+		SinkFileCounters       []ScanSummaryFileCounter
+		SurceFileCounters      []ScanSummaryFileCounter
+		LanguageCounters       []ScanSummaryLanguageCounter
+		ComplianceCounters     []ScanSummaryComplianceCounter
+		SeverityCounters       []ScanSummarySeverityCounter
+		StatusCounters         []ScanSummaryStatusCounter
+		StateCounters          []ScanSummaryStateCounter
+		SeverityStatusCounters []ScanSummarySeverityStatusCounter
+		TotalCounter           uint64
+		FilesScannedCounter    uint64
 	}
+
 	// ignoring the other counters
 	// KICSCounters
 	// SCACounters
 	// SCAPackagesCounters
 	// SCAContainerCounters
 	// APISecCounters
+}
+
+type ScanSummaryAgeCounter struct {
+	Age              string
+	SeverityCounters []ScanSummarySeverityCounter
+	Counter          uint64
+}
+type ScanSummaryComplianceCounter struct {
+	Compliance string
+	Counter    uint64
+}
+type ScanSummaryFileCounter struct {
+	File    string
+	Counter uint64
+}
+type ScanSummaryLanguageCounter struct {
+	Language string
+	Counter  uint64
+}
+type ScanSummaryQueriesCounter struct {
+	QueryID        uint64                     `json:"queryID"`
+	Name           uint64                     `json:"queryName"`
+	Severity       string                     `json:"severity"`
+	StatusCounters []ScanSummaryStatusCounter `json:"statusCounters"`
+	Counter        uint64                     `json:"counter"`
+}
+type ScanSummarySeverityCounter struct {
+	Severity string
+	Counter  uint64
+}
+type ScanSummarySeverityStatusCounter struct {
+	Severity string
+	Status   string
+	Counter  uint64
+}
+type ScanSummaryStateCounter struct {
+	State   string
+	Counter uint64
+}
+type ScanSummaryStatusCounter struct {
+	Status  string
+	Counter uint64
+}
+
+type ScanSummaryFilter struct {
+	BaseFilter
+	ScanIDs        []string `url:"scan-ids"`
+	SeverityStatus bool     `url:"include-severity-status"`
+	Status         bool     `url:"include-status-counters"`
+	Queries        bool     `url:"include-queries"`
+	Files          bool     `url:"include-files"`
+	Predicates     bool     `url:"apply-predicates"`
+	Language       string   `url:"language"`
+	ExcludeTypes   []string `url:"exclude-result-types"` // DEV_AND_TEST, NONE
 }
 
 type Status struct {

--- a/types.go
+++ b/types.go
@@ -515,10 +515,12 @@ type ScanResultSet struct {
 	SCA          []ScanSCAResult
 	SCAContainer []ScanSCAContainerResult
 	KICS         []ScanKICSResult
+	Containers   []ScanContainersResult
 }
 
 type ScanResultsFilter struct {
 	BaseFilter
+	ScanID             string   `url:"scan-id"`
 	Severity           []string `url:"severity"`
 	State              []string `url:"state"`
 	Status             []string `url:"status"`
@@ -541,6 +543,39 @@ type ScanResultBase struct {
 	FirstScanId     string
 	Description     string
 	// Comments			// currently doesn't do anything?
+}
+
+type ScanContainersResult struct {
+	ScanResultBase
+	Data                 ScanContainersResultData
+	VulnerabilityDetails ScanContainersResultDetails
+}
+
+type ScanContainersResultData struct {
+	PackageName    string
+	PackageVersion string
+	ImageName      string
+	ImageTag       string
+	ImageFilePath  string
+	ImageOrigin    string
+}
+
+type ScanContainersResultDetails struct {
+	CVSSScore float64
+	CveName   string
+	CweID     string
+	Cvss      struct {
+		Scope                 string
+		Score                 string
+		Severity              string
+		AttackVector          string `json:"attack_vector"`
+		IntegrityImpact       string `json:"integrity_impact"`
+		UserInteraction       string `json:"user_interaction"`
+		AttackComplexity      string `json:"attack_complexity"`
+		AvailabilityImpact    string `json:"availability_impact"`
+		PrivilegesRequired    string `json:"privileges_required"`
+		ConfidentialityImpact string `json:"confidentiality_impact"`
+	}
 }
 
 type ScanKICSResult struct {
@@ -678,23 +713,108 @@ type ScanSummary struct {
 	SASTCounters struct {
 		QueriesCounters        []ScanSummaryQueriesCounter
 		SinkFileCounters       []ScanSummaryFileCounter
-		SurceFileCounters      []ScanSummaryFileCounter
 		LanguageCounters       []ScanSummaryLanguageCounter
 		ComplianceCounters     []ScanSummaryComplianceCounter
 		SeverityCounters       []ScanSummarySeverityCounter
 		StatusCounters         []ScanSummaryStatusCounter
 		StateCounters          []ScanSummaryStateCounter
 		SeverityStatusCounters []ScanSummarySeverityStatusCounter
-		TotalCounter           uint64
-		FilesScannedCounter    uint64
+		SourceFileCounters     []ScanSummaryFileCounter
+		AgeCounters            []ScanSummaryAgeCounter
+
+		TotalCounter        uint64
+		FilesScannedCounter uint64
 	}
 
-	// ignoring the other counters
-	// KICSCounters
-	// SCACounters
-	// SCAPackagesCounters
-	// SCAContainerCounters
-	// APISecCounters
+	KICSCounters struct {
+		SeverityCounters       []ScanSummarySeverityCounter
+		StatusCounters         []ScanSummaryStatusCounter
+		StateCounters          []ScanSummaryStateCounter
+		SeverityStatusCounters []ScanSummarySeverityStatusCounter
+		SourceFileCounters     []ScanSummaryFileCounter
+		AgeCounters            []ScanSummaryAgeCounter
+
+		TotalCounter        uint64
+		FilesScannedCounter uint64
+
+		PlatformSummary []ScanSummaryPlatformCounter
+		CategorySummary []ScanSummaryCategoryCounter
+	}
+
+	SCACounters struct {
+		SeverityCounters       []ScanSummarySeverityCounter
+		StatusCounters         []ScanSummaryStatusCounter
+		StateCounters          []ScanSummaryStateCounter
+		SeverityStatusCounters []ScanSummarySeverityStatusCounter
+		SourceFileCounters     []ScanSummaryFileCounter
+		AgeCounters            []ScanSummaryAgeCounter
+
+		TotalCounter        uint64
+		FilesScannedCounter uint64
+	}
+
+	SCAPackagesCounters struct {
+		SeverityCounters       []ScanSummarySeverityCounter
+		StatusCounters         []ScanSummaryStatusCounter
+		StateCounters          []ScanSummaryStateCounter
+		SeverityStatusCounters []ScanSummarySeverityStatusCounter
+		SourceFileCounters     []ScanSummaryFileCounter
+		AgeCounters            []ScanSummaryAgeCounter
+
+		TotalCounter        uint64
+		FilesScannedCounter uint64
+		OutdatedCounter     uint64
+		RiskLevelCounters   []ScanSummaryRiskLevelCounter
+		LicenseCounters     []ScanSummaryLicenseCounter
+		PackageCounters     []ScanSummaryPackageCounter
+	}
+
+	SCAContainersCounters struct {
+		TotalPackagesCounters           uint64
+		TotalVulnerabilitiesCounter     uint64
+		SeverityVulnerabilitiesCounters []ScanSummarySeverityCounter
+		StateVulnerabilityCounters      []ScanSummaryStateCounter
+		StatusVulnerabilityCounters     []ScanSummaryStatusCounter
+		AgeVulnerabilityCounters        []ScanSummaryAgeCounter
+		PackageVulnerabilitiesCounters  []ScanSummaryPackageCounter
+	}
+
+	APISecCounters struct {
+		SeverityCounters       []ScanSummarySeverityCounter
+		StatusCounters         []ScanSummaryStatusCounter
+		StateCounters          []ScanSummaryStateCounter
+		SeverityStatusCounters []ScanSummarySeverityStatusCounter
+		SourceFileCounters     []ScanSummaryFileCounter
+		AgeCounters            []ScanSummaryAgeCounter
+
+		TotalCounter        uint64
+		FilesScannedCounter uint64
+		RiskLevel           string
+		APISecTotal         uint64
+	}
+
+	MicroEnginesCounters struct {
+		SeverityCounters       []ScanSummarySeverityCounter
+		StatusCounters         []ScanSummaryStatusCounter
+		StateCounters          []ScanSummaryStateCounter
+		SeverityStatusCounters []ScanSummarySeverityStatusCounter
+		SourceFileCounters     []ScanSummaryFileCounter
+		AgeCounters            []ScanSummaryAgeCounter
+
+		TotalCounter        uint64
+		FilesScannedCounter uint64
+	}
+
+	ContainersCounters struct {
+		TotalPackagesCounter   uint64
+		TotalCounter           uint64
+		SeverityCounters       []ScanSummarySeverityCounter
+		StatusCounters         []ScanSummaryStatusCounter
+		StateCounters          []ScanSummaryStateCounter
+		AgeCounters            []ScanSummaryAgeCounter
+		PackageCounters        []ScanSummaryContainerPackageCounter
+		SeverityStatusCounters []ScanSummarySeverityStatusCounter
+	}
 }
 
 type ScanSummaryAgeCounter struct {
@@ -714,12 +834,29 @@ type ScanSummaryLanguageCounter struct {
 	Language string
 	Counter  uint64
 }
+type ScanSummaryLicenseCounter struct {
+	License string
+	Counter uint64
+}
+type ScanSummaryPackageCounter struct {
+	Package string
+	Counter uint64
+}
+type ScanSummaryContainerPackageCounter struct {
+	Package     string
+	Counter     uint64
+	IsMalicious bool
+}
 type ScanSummaryQueriesCounter struct {
 	QueryID        uint64                     `json:"queryID"`
 	Name           uint64                     `json:"queryName"`
 	Severity       string                     `json:"severity"`
 	StatusCounters []ScanSummaryStatusCounter `json:"statusCounters"`
 	Counter        uint64                     `json:"counter"`
+}
+type ScanSummaryRiskLevelCounter struct {
+	RiskLevel string
+	Counter   uint64
 }
 type ScanSummarySeverityCounter struct {
 	Severity string
@@ -739,9 +876,18 @@ type ScanSummaryStatusCounter struct {
 	Counter uint64
 }
 
+type ScanSummaryPlatformCounter struct {
+	Platform string
+	Counter  uint64
+}
+type ScanSummaryCategoryCounter struct {
+	Category string
+	Counter  uint64
+}
+
 type ScanSummaryFilter struct {
 	BaseFilter
-	ScanIDs        []string `url:"scan-ids"`
+	ScanIDs        string   `url:"scan-ids"` // comma-separated list of scan ids
 	SeverityStatus bool     `url:"include-severity-status"`
 	Status         bool     `url:"include-status-counters"`
 	Queries        bool     `url:"include-queries"`


### PR DESCRIPTION
This is a fairly large update and may impact existing developments using Cx1ClientGo.

Pagination has been added to various parts of Cx1ClientGo. There is a PaginationSettings which defines the default page size and can be changed via Get/SetPaginationSettings.

Added various functions like:
- GetAllProjects - fetches all projects using default pagination
- GetProjectsFiltered(filter) - returns one page of results matching the filter (using filter.Offset and filter.Limit)
- GetXProjectsFiltered(filter,count) - returns 'count' projects using the default pagination
- GetAllProjectsFiltered(filter) - returns all projects matching the filter, using the default pagination

Existing functions have been updated to use the paginated Get*Filtered functions behind the scenes.

This applies to:
- Applications
- Projects
- Branches
- Scans
- Results
- Users
- Groups

Group functions have been additionally impacted due to back-end API changes, however existing functions (GetGroup*) should behave similarly with the same output as before. 

As this is a fairly low-level change there is a potential for bugs or differences in behavior from the previous version. Please report any issues directly via the Issues tab or email to michael.kubiaczyk@checkmarx.com
