### PR TITLE
adding oidcclient.SecretExpirationDays

### DIFF
--- a/types.go
+++ b/types.go
@@ -289,13 +289,14 @@ type GroupFilter struct {
 }
 
 type OIDCClient struct {
-	ID                 string                 `json:"id"`
-	ClientID           string                 `json:"clientId"`
-	Enabled            bool                   `json:"enabled"`
-	ClientSecret       string                 `json:"secret"`
-	ClientSecretExpiry uint64                 `json:"-"`
-	Creator            string                 `json:"-"`
-	OIDCClientRaw      map[string]interface{} `json:"-"`
+	ID                   string                 `json:"id"`
+	ClientID             string                 `json:"clientId"`
+	Enabled              bool                   `json:"enabled"`
+	ClientSecret         string                 `json:"secret"`
+	ClientSecretExpiry   uint64                 `json:"-"` // this is the actual time/date it will expire
+	SecretExpirationDays uint64                 `json:"-"` // this is the number of days after which a secret will expire
+	Creator              string                 `json:"-"`
+	OIDCClientRaw        map[string]interface{} `json:"-"`
 }
 
 type OIDCClientScope struct {


### PR DESCRIPTION
Added an OIDCClient member variable SecretExpirationDays - number of days before a client secret expires after a new secret is generated. This is in addition to the existing ClientSecretExpiry which is the specific date that the secret will expire.

Also renamed "SaveClient" to "UpdateClient" for consistency with other Update functions - for now SaveClient remains and forwards to UpdateClient with a warning about eventual deprecation.

Additionally, when calling UpdateClient the internal OIDCClientRaw map will be updated with the ClientSecretExpiry and SecretExpirationDays values (previously this required manually updating the OIDCClientRaw map member)