### PR TITLE
Add CreateProjectInApplicationWOPolling

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -48,7 +48,7 @@ func (c Cx1Client) CreateProject(projectname string, cx1_group_ids []string, tag
 	return project, err
 }
 
-func (c Cx1Client) CreateProjectInApplication(projectname string, cx1_group_ids []string, tags map[string]string, applicationId string) (Project, error) {
+func (c Cx1Client) CreateProjectInApplicationWOPolling(projectname string, cx1_group_ids []string, tags map[string]string, applicationId string) (Project, error) {
 	c.logger.Debugf("Create Project %v in applicationId %v", projectname, applicationId)
 	data := map[string]interface{}{
 		"name":        projectname,
@@ -102,6 +102,14 @@ func (c Cx1Client) CreateProjectInApplication(projectname string, cx1_group_ids 
 		return Project{}, err
 	}
 
+	return project, err
+}
+
+func (c Cx1Client) CreateProjectInApplication(projectname string, cx1_group_ids []string, tags map[string]string, applicationId string) (Project, error) {
+	project, err := c.CreateProjectInApplicationWOPolling(projectname, cx1_group_ids, tags, applicationId)
+	if err != nil {
+		return project, err
+	}
 	return c.ProjectInApplicationPollingByID(project.ProjectID, applicationId)
 }
 


### PR DESCRIPTION
CreateProjectInApplicationWOPolling will return directly after creating a project inside the application. This allows to speed up batch project creations.