### PR TITLE
Quick resume + analytics

### DIFF
--- a/analytics.go
+++ b/analytics.go
@@ -1,0 +1,138 @@
+package Cx1ClientGo
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// refer to https://checkmarx.stoplight.io/docs/checkmarx-one-api-reference-guide/qf8welz2tlx8a-retrieve-analytics-kpi-data
+// Note that this is the "generic" internal function and so it is up to the consumer to unmarshal the response to the correct type
+// you can use the other analytics convenience functions to do this for you
+func (c Cx1Client) getAnalytics(kpi string, limit uint64, filter AnalyticsFilter) ([]byte, error) {
+	c.logger.Debugf("Fetching Analytics KPI %v", kpi)
+	var response []byte
+	type requestBodyStruct struct {
+		AnalyticsFilter
+		KPI   string `json:"kpi"`
+		Limit uint64 `json:"limit,omitempty"`
+	}
+
+	requestBody := requestBodyStruct{
+		AnalyticsFilter: filter,
+		KPI:             kpi,
+		Limit:           limit,
+	}
+	jsonBody, err := json.Marshal(requestBody)
+	if err != nil {
+		return response, err
+	}
+
+	return c.sendRequest(http.MethodPost, "/data_analytics/analyticsAPI/v1", bytes.NewReader(jsonBody), nil)
+}
+
+func (c Cx1Client) getAnalyticsDistributionStats(kpi string, filter AnalyticsFilter) (AnalyticsDistributionStats, error) {
+	var stats AnalyticsDistributionStats
+	bytes, err := c.getAnalytics(kpi, 0, filter)
+	if err != nil {
+		return stats, err
+	}
+	err = json.Unmarshal(bytes, &stats)
+	return stats, err
+}
+
+func (c Cx1Client) GetAnalyticsVulnerabilitiesBySeverityTotal(filter AnalyticsFilter) (AnalyticsDistributionStats, error) {
+	return c.getAnalyticsDistributionStats("vulnerabilitiesBySeverityTotal", filter)
+}
+
+func (c Cx1Client) GetAnalyticsVulnerabilitiesByStateTotal(filter AnalyticsFilter) (AnalyticsDistributionStats, error) {
+	return c.getAnalyticsDistributionStats("vulnerabilitiesByStateTotal", filter)
+}
+
+func (c Cx1Client) GetAnalyticsVulnerabilitiesByStatusTotal(filter AnalyticsFilter) (AnalyticsDistributionStats, error) {
+	return c.getAnalyticsDistributionStats("vulnerabilitiesByStatusTotal", filter)
+}
+
+func (c Cx1Client) GetAnalyticsVulnerabilitiesBySeverityAndStateTotal(filter AnalyticsFilter) ([]AnalyticsSeverityAndstateStats, error) {
+	var stats []AnalyticsSeverityAndstateStats
+	bytes, err := c.getAnalytics("vulnerabilitiesBySeverityAndStateTotal", 0, filter)
+	if err != nil {
+		return stats, err
+	}
+
+	err = json.Unmarshal(bytes, &stats)
+	return stats, err
+}
+
+func (c Cx1Client) getAnalyticsOverTimeStats(kpi string, filter AnalyticsFilter) ([]AnalyticsOverTimeStats, error) {
+	var response struct {
+		Distribution []AnalyticsOverTimeStats `json:"distribution"`
+	}
+
+	bytes, err := c.getAnalytics(kpi, 0, filter)
+	if err != nil {
+		return response.Distribution, err
+	}
+	err = json.Unmarshal(bytes, &response)
+	return response.Distribution, err
+}
+
+func (c Cx1Client) GetAnalyticsVulnerabilitiesBySeverityOvertime(filter AnalyticsFilter) ([]AnalyticsOverTimeStats, error) {
+	return c.getAnalyticsOverTimeStats("vulnerabilitiesBySeverityOvertime", filter)
+}
+
+func (c Cx1Client) GetAnalyticsFixedVulnerabilitiesBySeverityOvertime(filter AnalyticsFilter) ([]AnalyticsOverTimeStats, error) {
+	return c.getAnalyticsOverTimeStats("fixedVulnerabilitiesBySeverityOvertime", filter)
+}
+
+func (c Cx1Client) GetAnalyticsMeanTimeToResolution(filter AnalyticsFilter) (AnalyticsMeanTimeStats, error) {
+	var stats AnalyticsMeanTimeStats
+	bytes, err := c.getAnalytics("meanTimeToResolution", 0, filter)
+	if err != nil {
+		return stats, err
+	}
+	err = json.Unmarshal(bytes, &stats)
+	return stats, err
+}
+
+func (c Cx1Client) getAnalyticsVulnerabilityStats(kpi string, limit uint64, filter AnalyticsFilter) ([]AnalyticsVulnerabilitiesStats, error) {
+	var stats []AnalyticsVulnerabilitiesStats
+	bytes, err := c.getAnalytics(kpi, limit, filter)
+	if err != nil {
+		return stats, err
+	}
+	err = json.Unmarshal(bytes, &stats)
+	return stats, err
+}
+
+func (c Cx1Client) GetAnalyticsMostCommonVulnerabilities(limit uint64, filter AnalyticsFilter) ([]AnalyticsVulnerabilitiesStats, error) {
+	return c.getAnalyticsVulnerabilityStats("mostCommonVulnerabilities", limit, filter)
+}
+
+func (c Cx1Client) GetAnalyticsMostAgingVulnerabilities(limit uint64, filter AnalyticsFilter) ([]AnalyticsVulnerabilitiesStats, error) {
+	return c.getAnalyticsVulnerabilityStats("mostAgingVulnerabilities", limit, filter)
+}
+
+const AnalyticsTimeLayout = "2006-01-02 15:04:05"
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (ct *AnalyticsTime) UnmarshalJSON(b []byte) error {
+	// Trim quotes from the JSON string.
+	s := string(b[1 : len(b)-1])
+
+	var err error
+	ct.Time, err = time.Parse(AnalyticsTimeLayout, s)
+	if err == nil {
+		return nil
+	}
+
+	// If none of the layouts worked, return the last error.
+	return fmt.Errorf("failed to parse time: %w", err)
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (ct AnalyticsTime) MarshalJSON() ([]byte, error) {
+	return json.Marshal(ct.Time.Format(AnalyticsTimeLayout))
+}

--- a/cx1client.go
+++ b/cx1client.go
@@ -486,3 +486,7 @@ func (c *Cx1Client) GetAccessToken() (string, error) {
 
 	return token.AccessToken, nil
 }
+
+func (c *Cx1Client) GetCurrentUsername() string {
+	return c.claims.Username
+}

--- a/cx1client.go
+++ b/cx1client.go
@@ -1,19 +1,16 @@
 package Cx1ClientGo
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io"
 	"strings"
 	"time"
 
 	//"io/ioutil"
 	"net/http"
 
-	"github.com/golang-jwt/jwt/v4"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"
@@ -28,7 +25,7 @@ var cxOrigin = "Cx1-Client-GoLang"
 //var cx1UserAgent string = "Cx1ClientGo"
 
 // Main entry for users of this client when using OAuth Client ID & Client Secret:
-func NewOAuthClient(client *http.Client, base_url string, iam_url string, tenant string, client_id string, client_secret string, logger *logrus.Logger) (*Cx1Client, error) {
+func NewOAuthClient(client *http.Client, base_url, iam_url, tenant, client_id, client_secret string, logger *logrus.Logger) (*Cx1Client, error) {
 	if base_url == "" || iam_url == "" || tenant == "" || client_id == "" || client_secret == "" || logger == nil {
 		return nil, fmt.Errorf("unable to create client: invalid parameters provided")
 	}
@@ -52,36 +49,32 @@ func NewOAuthClient(client *http.Client, base_url string, iam_url string, tenant
 
 	oauthclient := conf.Client(ctx)
 
+	token, err := conf.Token(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	claims, err := parseJWT(token.AccessToken)
+	if err != nil {
+		return nil, err
+	}
+
 	cli := Cx1Client{
 		httpClient: oauthclient,
 		baseUrl:    base_url,
 		iamUrl:     iam_url,
 		tenant:     tenant,
-		logger:     logger}
-
-	token, err := conf.Token(ctx)
-	if err != nil {
-		return nil, err
-	} else {
-		cli.parseJWT(token.AccessToken)
+		logger:     logger,
+		claims:     claims,
+		IsUser:     false,
 	}
 
 	cli.InitializeClient(false)
-
-	oidcclient, err := cli.GetClientByName(client_id)
-	if err != nil {
-		logger.Warningf("Failed to retrieve information for OIDC Client %v", client_id)
-	} else {
-		user, _ := cli.GetServiceAccountByID(oidcclient.ID)
-		cli.user = &user
-	}
-
-	cli.IsUser = false
-
 	return &cli, nil
 }
 
-// Main entry for users of this client when using API Key
+// Old entry for users of this client when using API Key
+// You can use the new "FromAPIKey" initializer with fewer parameters
 func NewAPIKeyClient(client *http.Client, base_url string, iam_url string, tenant string, api_key string, logger *logrus.Logger) (*Cx1Client, error) {
 	if base_url == "" || iam_url == "" || tenant == "" || api_key == "" || logger == nil {
 		return nil, fmt.Errorf("unable to create client: invalid parameters provided")
@@ -118,20 +111,122 @@ func NewAPIKeyClient(client *http.Client, base_url string, iam_url string, tenan
 	}
 
 	oauthclient := conf.Client(ctx, token)
+	claims, err := parseJWT(token.AccessToken)
+	if err != nil {
+		return nil, err
+	}
 
 	cli := Cx1Client{
 		httpClient: oauthclient,
 		baseUrl:    base_url,
 		iamUrl:     iam_url,
 		tenant:     tenant,
-		logger:     logger}
+		logger:     logger,
+		claims:     claims,
+		IsUser:     true,
+		tenantID:   claims.TenantID,
+	}
 
 	cli.InitializeClient(false)
-	cli.parseJWT(token.AccessToken)
+	return &cli, nil
+}
 
-	_, _ = cli.GetCurrentUser()
-	cli.IsUser = true
+func FromAPIKey(client *http.Client, api_key string, logger *logrus.Logger) (*Cx1Client, error) {
+	var iam_url, tenant string
 
+	claims, err := parseJWT(api_key)
+	if err != nil {
+		return nil, err
+	}
+
+	iam_url = claims.IAMURL
+	tenant = claims.TenantName
+
+	ctx := context.Background()
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error { return http.ErrUseLastResponse }
+	ctx = context.WithValue(ctx, oauth2.HTTPClient, client)
+
+	conf := &oauth2.Config{
+		ClientID: "ast-app",
+		Endpoint: oauth2.Endpoint{
+			TokenURL: fmt.Sprintf("%v/auth/realms/%v/protocol/openid-connect/token", iam_url, tenant),
+		},
+	}
+
+	refreshToken := &oauth2.Token{
+		AccessToken:  "",
+		RefreshToken: api_key,
+		Expiry:       time.Now().UTC(),
+	}
+
+	token, err := conf.TokenSource(ctx, refreshToken).Token()
+	if err != nil {
+		fmt.Printf("Error: %s\n", err)
+		return nil, err
+	}
+
+	oauthclient := conf.Client(ctx, token)
+
+	claims, err = parseJWT(token.AccessToken)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse cx1 jwt token: %v", err)
+	}
+
+	cli := Cx1Client{
+		httpClient: oauthclient,
+		baseUrl:    claims.ASTBaseURL,
+		iamUrl:     iam_url,
+		tenant:     tenant,
+		logger:     logger,
+		claims:     claims,
+		tenantID:   claims.TenantID,
+		IsUser:     true,
+	}
+
+	cli.InitializeClient(true)
+	return &cli, nil
+}
+
+func FromToken(client *http.Client, last_token string, logger *logrus.Logger) (*Cx1Client, error) {
+	claims, err := parseJWT(last_token)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx := context.Background()
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error { return http.ErrUseLastResponse }
+	ctx = context.WithValue(ctx, oauth2.HTTPClient, client)
+
+	conf := &oauth2.Config{}
+
+	refreshToken := &oauth2.Token{
+		AccessToken: last_token,
+		Expiry:      claims.ExpiryTime.UTC(),
+	}
+
+	token, err := conf.TokenSource(ctx, refreshToken).Token()
+	if err != nil {
+		err = fmt.Errorf("failed getting a token: %s", err)
+		return nil, err
+	}
+
+	oauthclient := conf.Client(ctx, token)
+	claims, err = parseJWT(token.AccessToken)
+	if err != nil {
+		return nil, err
+	}
+
+	cli := Cx1Client{
+		httpClient: oauthclient,
+		baseUrl:    claims.ASTBaseURL,
+		iamUrl:     claims.IAMURL,
+		tenant:     claims.TenantName,
+		logger:     logger,
+		IsUser:     (claims.AZP == "ast-app"),
+		claims:     claims,
+	}
+
+	cli.InitializeClient(true)
 	return &cli, nil
 }
 
@@ -158,7 +253,7 @@ func ResumeAPIKeyClient(client *http.Client, base_url, iam_url, tenant, api_key,
 		},
 	}
 
-	expiry, err := parseJWTExpiry(last_token)
+	claims, err := parseJWT(last_token)
 	if err != nil {
 		logger.Warningf("Failed parsing last token: %s", err)
 	}
@@ -166,7 +261,7 @@ func ResumeAPIKeyClient(client *http.Client, base_url, iam_url, tenant, api_key,
 	refreshToken := &oauth2.Token{
 		AccessToken:  last_token,
 		RefreshToken: api_key,
-		Expiry:       expiry.UTC(),
+		Expiry:       claims.ExpiryTime.UTC(),
 	}
 
 	token, err := conf.TokenSource(ctx, refreshToken).Token()
@@ -177,18 +272,22 @@ func ResumeAPIKeyClient(client *http.Client, base_url, iam_url, tenant, api_key,
 	}
 
 	oauthclient := conf.Client(ctx, token)
+	claims, err = parseJWT(token.AccessToken)
+	if err != nil {
+		return nil, err
+	}
 
 	cli := Cx1Client{
 		httpClient: oauthclient,
 		baseUrl:    base_url,
 		iamUrl:     iam_url,
 		tenant:     tenant,
-		logger:     logger}
+		logger:     logger,
+		IsUser:     true,
+		claims:     claims,
+	}
 
 	cli.InitializeClient(true)
-	cli.parseJWT(token.AccessToken)
-	cli.IsUser = true
-
 	return &cli, nil
 }
 
@@ -217,153 +316,6 @@ func NewClient(client *http.Client, logger *logrus.Logger) (*Cx1Client, error) {
 	}
 }
 
-func (c Cx1Client) createRequest(method, url string, body io.Reader, header *http.Header, cookies []*http.Cookie) (*http.Request, error) {
-	request, err := http.NewRequest(method, url, body)
-	if err != nil {
-		return &http.Request{}, err
-	}
-
-	for name, headers := range *header {
-		for _, h := range headers {
-			request.Header.Add(name, h)
-		}
-	}
-
-	//request.Header.Set("Authorization", fmt.Sprintf("Bearer %v", c.authToken))
-	if request.Header.Get("User-Agent") == "" {
-		request.Header.Set("User-Agent", c.cx1UserAgent)
-	}
-
-	if request.Header.Get("Content-Type") == "" {
-		request.Header.Set("Content-Type", "application/json")
-	}
-
-	for _, cookie := range cookies {
-		request.AddCookie(cookie)
-	}
-
-	return request, nil
-}
-
-func (c Cx1Client) sendRequestInternal(method, url string, body io.Reader, header http.Header) ([]byte, error) {
-	response, err := c.sendRequestRaw(method, url, body, header)
-	var resBody []byte
-	if response != nil && response.Body != nil {
-		resBody, _ = io.ReadAll(response.Body)
-		response.Body.Close()
-	}
-
-	return resBody, err
-}
-
-func (c Cx1Client) sendRequestRaw(method, url string, body io.Reader, header http.Header) (*http.Response, error) {
-	var requestBody io.Reader
-	var bodyBytes []byte
-
-	c.logger.Tracef("Sending %v request to URL %v", method, url)
-
-	if body != nil {
-		closer := io.NopCloser(body)
-		bodyBytes, _ := io.ReadAll(closer)
-		requestBody = bytes.NewBuffer(bodyBytes)
-		defer closer.Close()
-	}
-
-	request, err := c.createRequest(method, url, requestBody, &header, nil)
-	if err != nil {
-		c.logger.Tracef("Unable to create request: %s", err)
-		return nil, err
-	}
-
-	response, err := c.httpClient.Do(request)
-	if err != nil {
-		// special handling: some proxies terminate connections resulting in a "remote error: tls: user canceled" failures
-		// the request actually succeeded and there is likely to be data in the response
-		if err.Error() == "remote error: tls: user canceled" {
-			c.logger.Warnf("Potentially benign error from HTTP connection: %s", err)
-			// continue processing as normal below
-		} else {
-			c.logger.Tracef("Failed HTTP request: '%s'", err)
-			var resBody []byte
-			if response != nil && response.Body != nil {
-				resBody, _ = io.ReadAll(response.Body)
-			}
-			c.recordRequestDetailsInErrorCase(bodyBytes, resBody)
-
-			return response, err
-		}
-	}
-	if response.StatusCode >= 400 {
-		resBody, _ := io.ReadAll(response.Body)
-		c.recordRequestDetailsInErrorCase(bodyBytes, resBody)
-		var msg map[string]interface{}
-		err = json.Unmarshal(resBody, &msg)
-		if err == nil {
-			var str string
-			if msg["message"] != nil {
-				str = msg["message"].(string)
-			} else if msg["error_description"] != nil {
-				str = msg["error_description"].(string)
-			} else if msg["error"] != nil {
-				str = msg["error"].(string)
-			} else if msg["errorMessage"] != nil {
-				str = msg["errorMessage"].(string)
-			} else {
-				if len(str) > 20 {
-					str = string(resBody)[:20]
-				} else {
-					str = string(resBody)
-				}
-			}
-			return response, fmt.Errorf("HTTP %v: %v", response.Status, str)
-		} else {
-			str := string(resBody)
-			if len(str) > 20 {
-				str = str[:20]
-			}
-			return response, fmt.Errorf("HTTP %v: %s", response.Status, str)
-		}
-		//return response, fmt.Errorf("HTTP Response: " + response.Status)
-	}
-
-	return response, nil
-}
-
-func (c Cx1Client) sendRequest(method, url string, body io.Reader, header http.Header) ([]byte, error) {
-	cx1url := fmt.Sprintf("%v/api%v", c.baseUrl, url)
-	return c.sendRequestInternal(method, cx1url, body, header)
-}
-
-func (c Cx1Client) sendRequestRawCx1(method, url string, body io.Reader, header http.Header) (*http.Response, error) {
-	cx1url := fmt.Sprintf("%v/api%v", c.baseUrl, url)
-	return c.sendRequestRaw(method, cx1url, body, header)
-}
-
-func (c Cx1Client) sendRequestIAM(method, base, url string, body io.Reader, header http.Header) ([]byte, error) {
-	iamurl := fmt.Sprintf("%v%v/realms/%v%v", c.iamUrl, base, c.tenant, url)
-	return c.sendRequestInternal(method, iamurl, body, header)
-}
-
-func (c Cx1Client) sendRequestRawIAM(method, base, url string, body io.Reader, header http.Header) (*http.Response, error) {
-	iamurl := fmt.Sprintf("%v%v/realms/%v%v", c.iamUrl, base, c.tenant, url)
-	return c.sendRequestRaw(method, iamurl, body, header)
-}
-
-// not sure what to call this one? used for /console/ calls, not part of the /realms/ path
-func (c Cx1Client) sendRequestOther(method, base, url string, body io.Reader, header http.Header) ([]byte, error) {
-	iamurl := fmt.Sprintf("%v%v/%v%v", c.iamUrl, base, c.tenant, url)
-	return c.sendRequestInternal(method, iamurl, body, header)
-}
-
-func (c Cx1Client) recordRequestDetailsInErrorCase(requestBody []byte, responseBody []byte) {
-	if len(requestBody) != 0 {
-		c.logger.Tracef("Request body: %s", string(requestBody))
-	}
-	if len(responseBody) != 0 {
-		c.logger.Tracef("Response body: %s", string(responseBody))
-	}
-}
-
 func (c Cx1Client) String() string {
 	return fmt.Sprintf("%v on %v ", c.tenant, c.baseUrl)
 }
@@ -377,6 +329,18 @@ func (c *Cx1Client) InitializeClient(quick bool) error {
 
 		if err := c.RefreshFlags(); err != nil {
 			c.logger.Warnf("Failed to get tenant flags: %s", err)
+		}
+
+		if !c.IsUser {
+			oidcclient, err := c.GetClientByName(c.claims.ClientID)
+			if err != nil {
+				c.logger.Warningf("Failed to retrieve information for OIDC Client %v", c.claims.ClientID)
+			} else {
+				user, _ := c.GetServiceAccountByID(oidcclient.ID)
+				c.user = &user
+			}
+		} else {
+			_, _ = c.GetCurrentUser()
 		}
 	}
 	cxVersion, err := c.GetVersion()
@@ -430,41 +394,6 @@ func (c *Cx1Client) RefreshFlags() error {
 	c.flags = flags
 
 	return nil
-}
-
-func (c *Cx1Client) parseJWT(jwtToken string) error {
-	_, err := jwt.ParseWithClaims(jwtToken, &c.claims, func(token *jwt.Token) (interface{}, error) {
-		return []byte(nil), nil
-	})
-	return err
-}
-
-func parseJWTExpiry(last_token string) (time.Time, error) {
-	// Parse the JWT token to get the claims
-	parser := new(jwt.Parser)
-	tokenClaims := jwt.MapClaims{}
-	_, _, err := parser.ParseUnverified(last_token, &tokenClaims)
-	if err != nil {
-		return time.Now(), fmt.Errorf("failed to parse JWT token: %w", err)
-	}
-
-	// Extract the expiration time from the claims
-	if exp, ok := tokenClaims["exp"]; ok {
-		switch exp := exp.(type) {
-		case float64:
-			return time.Unix(int64(exp), 0), nil
-		case json.Number:
-			expInt, err := exp.Int64()
-			if err != nil {
-				return time.Now(), fmt.Errorf("failed to parse exp claim as int64: %v", err)
-			}
-			return time.Unix(expInt, 0), nil
-		default:
-			return time.Now(), fmt.Errorf("unexpected type for exp claim: %T", exp)
-		}
-	} else {
-		return time.Now(), fmt.Errorf("exp claim not found in JWT token")
-	}
 }
 
 func (c Cx1Client) GetFlags() map[string]bool {
@@ -539,23 +468,7 @@ func (c Cx1Client) GetVersion() (VersionInfo, error) {
 	return v, nil
 }
 
-func (c Cx1Client) GetUserAgent() string {
-	return c.cx1UserAgent
-}
-func (c *Cx1Client) SetUserAgent(ua string) {
-	c.cx1UserAgent = ua
-}
-
-// this function set the U-A to be the old one that was previously default in Cx1ClientGo
-func (c *Cx1Client) SetUserAgentFirefox() {
-	c.cx1UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:105.0) Gecko/20100101 Firefox/105.0"
-}
-
 func (c *Cx1Client) GetAccessToken() (string, error) {
-	if c.httpClient == nil {
-		return "", fmt.Errorf("http client is not initialized")
-	}
-
 	// Check if the Transport is an oauth2.Transport
 	transport, ok := c.httpClient.Transport.(*oauth2.Transport)
 	if !ok {

--- a/plumbing.go
+++ b/plumbing.go
@@ -1,0 +1,211 @@
+package Cx1ClientGo
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+)
+
+// this file is for cx1clientgo internal functionality like sending HTTP requests
+
+func (c Cx1Client) createRequest(method, url string, body io.Reader, header *http.Header, cookies []*http.Cookie) (*http.Request, error) {
+	request, err := http.NewRequest(method, url, body)
+	if err != nil {
+		return &http.Request{}, err
+	}
+
+	for name, headers := range *header {
+		for _, h := range headers {
+			request.Header.Add(name, h)
+		}
+	}
+
+	//request.Header.Set("Authorization", fmt.Sprintf("Bearer %v", c.authToken))
+	if request.Header.Get("User-Agent") == "" {
+		request.Header.Set("User-Agent", c.cx1UserAgent)
+	}
+
+	if request.Header.Get("Content-Type") == "" {
+		request.Header.Set("Content-Type", "application/json")
+	}
+
+	for _, cookie := range cookies {
+		request.AddCookie(cookie)
+	}
+
+	return request, nil
+}
+
+func (c Cx1Client) sendRequestInternal(method, url string, body io.Reader, header http.Header) ([]byte, error) {
+	response, err := c.sendRequestRaw(method, url, body, header)
+	var resBody []byte
+	if response != nil && response.Body != nil {
+		resBody, _ = io.ReadAll(response.Body)
+		response.Body.Close()
+	}
+
+	return resBody, err
+}
+
+func (c Cx1Client) sendRequestRaw(method, url string, body io.Reader, header http.Header) (*http.Response, error) {
+	var requestBody io.Reader
+	var bodyBytes []byte
+
+	c.logger.Tracef("Sending %v request to URL %v", method, url)
+
+	if body != nil {
+		closer := io.NopCloser(body)
+		bodyBytes, _ := io.ReadAll(closer)
+		requestBody = bytes.NewBuffer(bodyBytes)
+		defer closer.Close()
+	}
+
+	request, err := c.createRequest(method, url, requestBody, &header, nil)
+	if err != nil {
+		c.logger.Tracef("Unable to create request: %s", err)
+		return nil, err
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		// special handling: some proxies terminate connections resulting in a "remote error: tls: user canceled" failures
+		// the request actually succeeded and there is likely to be data in the response
+		if err.Error() == "remote error: tls: user canceled" {
+			c.logger.Warnf("Potentially benign error from HTTP connection: %s", err)
+			// continue processing as normal below
+		} else {
+			c.logger.Tracef("Failed HTTP request: '%s'", err)
+			var resBody []byte
+			if response != nil && response.Body != nil {
+				resBody, _ = io.ReadAll(response.Body)
+			}
+			c.recordRequestDetailsInErrorCase(bodyBytes, resBody)
+
+			return response, err
+		}
+	}
+	if response.StatusCode >= 400 {
+		resBody, _ := io.ReadAll(response.Body)
+		c.recordRequestDetailsInErrorCase(bodyBytes, resBody)
+		var msg map[string]interface{}
+		err = json.Unmarshal(resBody, &msg)
+		if err == nil {
+			var str string
+			if msg["message"] != nil {
+				str = msg["message"].(string)
+			} else if msg["error_description"] != nil {
+				str = msg["error_description"].(string)
+			} else if msg["error"] != nil {
+				str = msg["error"].(string)
+			} else if msg["errorMessage"] != nil {
+				str = msg["errorMessage"].(string)
+			} else {
+				if len(str) > 20 {
+					str = string(resBody)[:20]
+				} else {
+					str = string(resBody)
+				}
+			}
+			return response, fmt.Errorf("HTTP %v: %v", response.Status, str)
+		} else {
+			str := string(resBody)
+			if len(str) > 20 {
+				str = str[:20]
+			}
+			return response, fmt.Errorf("HTTP %v: %s", response.Status, str)
+		}
+		//return response, fmt.Errorf("HTTP Response: " + response.Status)
+	}
+
+	return response, nil
+}
+
+func (c Cx1Client) sendRequest(method, url string, body io.Reader, header http.Header) ([]byte, error) {
+	cx1url := fmt.Sprintf("%v/api%v", c.baseUrl, url)
+	return c.sendRequestInternal(method, cx1url, body, header)
+}
+
+func (c Cx1Client) sendRequestRawCx1(method, url string, body io.Reader, header http.Header) (*http.Response, error) {
+	cx1url := fmt.Sprintf("%v/api%v", c.baseUrl, url)
+	return c.sendRequestRaw(method, cx1url, body, header)
+}
+
+func (c Cx1Client) sendRequestIAM(method, base, url string, body io.Reader, header http.Header) ([]byte, error) {
+	iamurl := fmt.Sprintf("%v%v/realms/%v%v", c.iamUrl, base, c.tenant, url)
+	return c.sendRequestInternal(method, iamurl, body, header)
+}
+
+func (c Cx1Client) sendRequestRawIAM(method, base, url string, body io.Reader, header http.Header) (*http.Response, error) {
+	iamurl := fmt.Sprintf("%v%v/realms/%v%v", c.iamUrl, base, c.tenant, url)
+	return c.sendRequestRaw(method, iamurl, body, header)
+}
+
+// not sure what to call this one? used for /console/ calls, not part of the /realms/ path
+func (c Cx1Client) sendRequestOther(method, base, url string, body io.Reader, header http.Header) ([]byte, error) {
+	iamurl := fmt.Sprintf("%v%v/%v%v", c.iamUrl, base, c.tenant, url)
+	return c.sendRequestInternal(method, iamurl, body, header)
+}
+
+func (c Cx1Client) recordRequestDetailsInErrorCase(requestBody []byte, responseBody []byte) {
+	if len(requestBody) != 0 {
+		c.logger.Tracef("Request body: %s", string(requestBody))
+	}
+	if len(responseBody) != 0 {
+		c.logger.Tracef("Response body: %s", string(responseBody))
+	}
+}
+
+func parseJWT(jwtToken string) (claims Cx1Claims, err error) {
+	_, err = jwt.ParseWithClaims(jwtToken, &claims, func(token *jwt.Token) (interface{}, error) {
+		return []byte(nil), nil
+	})
+
+	if err != nil && !errors.Is(err, jwt.ErrTokenUnverifiable) && !errors.Is(err, jwt.ErrTokenSignatureInvalid) {
+		err = fmt.Errorf("failed to parse cx1 jwt token: %v", err)
+		return
+	}
+
+	if claims.ISS != "" {
+		var issURL *url.URL
+		issURL, err = url.Parse(claims.ISS)
+		if err != nil {
+			err = fmt.Errorf("failed to parse iss claim as URL: %v", err)
+			return
+		}
+
+		if claims.IAMURL == "" {
+			claims.IAMURL = fmt.Sprintf("%v://%v", issURL.Scheme, issURL.Host)
+		}
+
+		parts := strings.Split(issURL.Path, "/")
+		if claims.TenantName == "" {
+			claims.TenantName = parts[len(parts)-1:][0]
+		}
+	}
+
+	if claims.Expiry != 0 {
+		claims.ExpiryTime = time.Unix(claims.Expiry, 0)
+	}
+
+	return
+}
+
+func (c Cx1Client) GetUserAgent() string {
+	return c.cx1UserAgent
+}
+func (c *Cx1Client) SetUserAgent(ua string) {
+	c.cx1UserAgent = ua
+}
+
+// this function set the U-A to be the old one that was previously default in Cx1ClientGo
+func (c *Cx1Client) SetUserAgentFirefox() {
+	c.cx1UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:105.0) Gecko/20100101 Firefox/105.0"
+}

--- a/scans.go
+++ b/scans.go
@@ -707,6 +707,25 @@ func (s ScanMetrics) GetLanguages() []string {
 	return langs
 }
 
+func (s *ScanConfigurationSet) AddConfig(engine, key, value string) {
+	for i := range s.Configurations {
+		if s.Configurations[i].ScanType == engine {
+			if key != "" {
+				s.Configurations[i].Values[key] = value
+			}
+			return
+		}
+	}
+	newconf := ScanConfiguration{
+		ScanType: engine,
+		Values:   map[string]string{},
+	}
+	if key != "" {
+		newconf.Values[key] = value
+	}
+	s.Configurations = append(s.Configurations, newconf)
+}
+
 /* misc future stuff
 
 Listing of files in a scan:

--- a/types.go
+++ b/types.go
@@ -595,6 +595,10 @@ type ScanConfiguration struct {
 	Values   map[string]string `json:"value"`
 }
 
+type ScanConfigurationSet struct {
+	Configurations []ScanConfiguration
+}
+
 type ScanHandler struct {
 	RepoURL     string                 `json:"repoUrl"`
 	Branch      string                 `json:"branch"`

--- a/types.go
+++ b/types.go
@@ -142,6 +142,80 @@ type AccessibleResource struct {
 	Roles        []string `json:"roles"`
 }
 
+type AnalyticsTime struct {
+	time.Time
+}
+
+type AnalyticsFilter struct {
+	Projects        []string       `json:"projects,omitempty"`
+	Applications    []string       `json:"applications,omitempty"`
+	Scanners        []string       `json:"scanners,omitempty"`
+	ApplicationTags []string       `json:"applicationTags,omitempty"`
+	ProjectTags     []string       `json:"projectTags,omitempty"`
+	ScanTags        []string       `json:"scanTags,omitempty"`
+	States          []string       `json:"states,omitempty"`
+	Status          []string       `json:"status,omitempty"`
+	Severities      []string       `json:"severities,omitempty"`
+	BranchNames     []string       `json:"branchNames,omitempty"`
+	Timezone        string         `json:"timezone,omitempty"`
+	Groups          []string       `json:"groupIds,omitempty"`
+	StartDate       *AnalyticsTime `json:"startDate,omitempty"`
+	EndDate         *AnalyticsTime `json:"endDate,omitempty"`
+}
+
+type AnalyticsDistributionEntry struct {
+	Label      string  `json:"label"`
+	Density    float32 `json:"density"`
+	Percentage float32 `json:"percentage"`
+	Results    uint64  `json:"results"`
+}
+type AnalyticsDistributionBlock struct {
+	Label  string                       `json:"label"`
+	Values []AnalyticsDistributionEntry `json:"values"`
+}
+type AnalyticsDistributionStats struct {
+	Distribution []AnalyticsDistributionBlock `json:"distribution"`
+	LOC          uint64                       `json:"loc"`
+	Total        uint64                       `json:"total"`
+}
+
+type AnalyticsOverTimeEntry struct {
+	Time  uint64        `json:"time"`
+	Value float32       `json:"value"`
+	Date  AnalyticsTime `json:"date"`
+}
+type AnalyticsOverTimeStats struct {
+	Label  string                   `json:"label"`
+	Values []AnalyticsOverTimeEntry `json:"values"`
+}
+
+type AnalyticsSeverityAndStateEntry struct {
+	Label   string `json:"label"`
+	Results int64  `json:"results"`
+}
+type AnalyticsSeverityAndstateStats struct {
+	Label      string                           `json:"label"`
+	Results    int64                            `json:"results"`
+	Severities []AnalyticsSeverityAndStateEntry `json:"severities"`
+}
+
+type AnalyticsMeanTimeEntry struct {
+	Label    string `json:"label"`
+	Results  int64  `json:"results"`
+	MeanTime int64  `json:"meanTime"`
+}
+type AnalyticsMeanTimeStats struct {
+	MeanTimeData      []AnalyticsMeanTimeEntry `json:"meanTimeData"`
+	MeanTimeStateData []AnalyticsMeanTimeEntry `json:"meanTimeStateData"`
+	TotalResults      int64                    `json:"totalResults"`
+}
+
+type AnalyticsVulnerabilitiesStats struct {
+	VulnerabilityName string                           `json:"vulnerabilityName"`
+	Total             int64                            `json:"total"`
+	Severities        []AnalyticsSeverityAndStateEntry `json:"severities"`
+}
+
 type Application struct {
 	ApplicationID string            `json:"id"`
 	Name          string            `json:"name"`

--- a/types.go
+++ b/types.go
@@ -33,6 +33,7 @@ type Cx1Claims struct {
 	jwt.RegisteredClaims
 	Cx1License    ASTLicense `json:"ast-license"`
 	IsServiceUser string     `json:"is-service-user"`
+	ISS           string     `json:"iss"`
 	UserID        string     `json:"sub"`
 	Username      string     `json:"name"`
 	ClientID      string     `json:"clientId"`
@@ -40,6 +41,12 @@ type Cx1Claims struct {
 	TenantID      string     `json:"tenant_id"`
 	TenantName    string     `json:"tenant_name"`
 	Email         string     `json:"email"`
+	Expiry        int64      `json:"exp"`
+	AZP           string     `json:"azp"`
+
+	// the following are generated during parsing
+	IAMURL     string    `json:"-"`
+	ExpiryTime time.Time `json:"-"`
 }
 type ASTLicense struct {
 	ID          int


### PR DESCRIPTION
There are some new functions added for creating a cx1clientgo client to support resuming a session using a pre-existing access token, to speed up the initialization of the client and allow Cx1 access via access-token-only (no authentication credentials supplied & no token regeneration).

Additionally, support for the Analytics KPIs has been added.