### PR TITLE
Fix redirect handling + added http-retry mechanism

### DIFF
--- a/types.go
+++ b/types.go
@@ -27,6 +27,8 @@ type Cx1Client struct {
 	tenantID     string
 	cx1UserAgent string
 	tenantOwner  *TenantOwner
+	maxRetries   int
+	retryDelay   int
 }
 
 type Cx1Claims struct {


### PR DESCRIPTION
There was an issue when using a hashicorp retryablehttp client in combination with the oauth2 library which caused redirects to be automatically followed, breaking some functionality in Cx1ClientGo which expected to find the Location response header in the redirect message. This update adds configurable retries (via Get/SetRetries - by default 3 retries at 15/30/60 seconds) which trigger automatically for HTTP 5xx errors or other transient failures (DNS lookup or connection timeout). 

It is recommended that you do not use the retryablehttp client in combination with Cx1ClientGo.