### PR TITLE
Fixes for clients used only with access tokens

### DIFF
--- a/cx1client.go
+++ b/cx1client.go
@@ -111,8 +111,10 @@ func NewClientWithOptions(options Cx1ClientConfiguration) (*Cx1Client, error) {
 }
 
 func (c *Cx1Client) InitializeClient(quick bool) error {
-	if err := c.refreshAccessToken(); err != nil {
-		return err
+	if c.config.Auth.AccessToken == "" {
+		if err := c.refreshAccessToken(); err != nil {
+			return err
+		}
 	}
 
 	c.parseToken()

--- a/cx1clientconfiguration.go
+++ b/cx1clientconfiguration.go
@@ -52,16 +52,18 @@ func (c *Cx1ClientConfiguration) Validate() error {
 		}
 	}
 
-	if c.Auth.APIKey != "" {
-		if err := c.ParseToken(c.Auth.APIKey); err != nil {
-			return err
-		}
-	} else {
-		if c.Auth.ClientID == "" {
-			return fmt.Errorf("no client id set")
-		}
-		if c.Auth.ClientSecret == "" {
-			return fmt.Errorf("no client secret set")
+	if c.Auth.AccessToken == "" {
+		if c.Auth.APIKey != "" {
+			if err := c.ParseToken(c.Auth.APIKey); err != nil {
+				return err
+			}
+		} else {
+			if c.Auth.ClientID == "" {
+				return fmt.Errorf("no client id set")
+			}
+			if c.Auth.ClientSecret == "" {
+				return fmt.Errorf("no client secret set")
+			}
 		}
 	}
 

--- a/plumbing.go
+++ b/plumbing.go
@@ -324,6 +324,7 @@ func (c *Cx1Client) parseToken() {
 	}
 
 	c.claims = claims
+	c.config.Auth.Expiry = claims.ExpiryTime
 	if claims.TenantID != "" {
 		c.tenantID = claims.TenantID
 	}


### PR DESCRIPTION
1. fix initialization failure with "no client id" error
2. fix attempts to refresh the token when only the access token is provided and it is not expired

Regarding (2), more fixes are probably needed because the current code will probably still attempt to refresh the token if it is going to expire soon (and it will fail because there is no refresh token).
