### PR TITLE
correcting comments + adding deprecation warning for scan-summary

### DIFF
--- a/access.go
+++ b/access.go
@@ -34,8 +34,8 @@ func (c *Cx1Client) GetAccessAssignmentByID(entityId, resourceId string) (Access
 // Create a new access assignment object and issue it to the platform.
 // If only the project is provided: project-level access.
 // If only the application is provided: application-level access.
-// If the tenant bool is set (regardless of project/application): tenant-level access.
-// Similar behavior for the user, group, and client pointers
+// If neither project or application is set: tenant-level access.
+// The access will only use the first non-nil: user, group, or client
 func (c *Cx1Client) CreateAccessAssignment(user *User, group *Group, client *OIDCClient, project *Project, application *Application, roles []AccessAssignedRole) (AccessAssignment, error) {
 	aa := AccessAssignment{
 		EntityRoles: roles,

--- a/scans.go
+++ b/scans.go
@@ -453,6 +453,7 @@ func (c *Cx1Client) GetScanSummariesByID(scanIDs []string) ([]ScanSummary, error
 
 // Return a list of scan summaries for scans matching the filter
 func (c *Cx1Client) GetScanSummariesFiltered(filter ScanSummaryFilter) ([]ScanSummary, error) {
+	c.depwarn("GetScanSummaries*", "GetScanSASTAggregateSummary*")
 	var ScansSummaries struct {
 		BaseFilteredResponse
 		ScanSum []ScanSummary `json:"scansSummaries"`


### PR DESCRIPTION
- Incorrect comment on the CreateAccessAssignment fixed
- GetScanSummaries* functions marked for deprecation, see https://checkmarx.stoplight.io/docs/checkmarx-one-api-reference-guide/zpp8t0jh1xwq8-retrieve-summary-of-scan-results