### PR TITLE
Fix query executable defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .checkmarx*
 .claude
+.spec

--- a/_examples/AccessManagement/AccessManagement.go
+++ b/_examples/AccessManagement/AccessManagement.go
@@ -25,7 +25,7 @@ func main() {
 	logger.Infof("Starting")
 
 	httpClient := &http.Client{}
-	if true {
+	if false {
 		proxyURL, _ := url.Parse("http://127.0.0.1:8080")
 		transport := &http.Transport{}
 		transport.Proxy = http.ProxyURL(proxyURL)

--- a/_examples/QueryManipulation/QueryManipulation.go
+++ b/_examples/QueryManipulation/QueryManipulation.go
@@ -357,6 +357,7 @@ func newSASTProjectOverride(cx1client *Cx1ClientGo.Cx1Client, logger *logrus.Log
 
 func newSASTCorpQuery(cx1client *Cx1ClientGo.Cx1Client, logger *logrus.Logger, qc *Cx1ClientGo.SASTQueryCollection, session *Cx1ClientGo.AuditSession) *Cx1ClientGo.SASTQuery {
 	logger.Infof("Creating corp query under session %v", session.ID)
+	tb := true
 	NewQuery := Cx1ClientGo.SASTQuery{
 		Source:             "result = Find_Strings().FindByName(\"test\"); // new corp query",
 		Name:               "Test_String",
@@ -364,7 +365,7 @@ func newSASTCorpQuery(cx1client *Cx1ClientGo.Cx1Client, logger *logrus.Logger, q
 		Language:           "Java",
 		Severity:           "Low",
 		CweID:              123,
-		IsExecutable:       true,
+		IsExecutable:       &tb,
 		QueryDescriptionId: 123,
 	}
 

--- a/_examples/QueryManipulation/QueryManipulation.go
+++ b/_examples/QueryManipulation/QueryManipulation.go
@@ -27,7 +27,7 @@ func main() {
 	logger.Infof("Starting")
 
 	httpClient := &http.Client{}
-	if true {
+	if false {
 		proxyURL, _ := url.Parse("http://127.0.0.1:8080")
 		transport := &http.Transport{}
 		transport.Proxy = http.ProxyURL(proxyURL)

--- a/applications.go
+++ b/applications.go
@@ -15,8 +15,8 @@ var ApplicationTypes = struct {
 	Business string
 	Internal string
 }{
-	Business: "Business",
-	Internal: "Internal",
+	Business: "business",
+	Internal: "internal",
 }
 
 // Get the first count Applications

--- a/audit.go
+++ b/audit.go
@@ -437,6 +437,20 @@ func (c *Cx1Client) GetAuditIACQueryByID(auditSession *AuditSession, queryId str
 	return query, nil
 }
 
+func (c *Cx1Client) GetAllAuditSASTQueries(auditSession *AuditSession) (SASTQueryCollection, error) {
+	c.config.Logger.Debugf("Get all audit queries")
+
+	collection := SASTQueryCollection{}
+	querytree, err := c.getAuditQueryTreeByLevelID(auditSession, "")
+	if err != nil {
+		return collection, err
+	}
+
+	collection.AddQueryTree(&querytree, auditSession.ApplicationID, auditSession.ProjectID)
+
+	return collection, nil
+}
+
 /*
 Retrieves the list of queries available for this audit session. Level and LevelID options are:
 QueryTypeProduct(), QueryTypeProduct() : same value for both when retrieving product-default queries
@@ -446,15 +460,15 @@ QueryTypeProject(), project.ProjectID : when retrieving project-level queries (i
 The resulting array of queries should be merged into a QueryCollection object returned by the GetQueries function.
 */
 func (c *Cx1Client) GetAuditSASTQueriesByLevelID(auditSession *AuditSession, level, levelId string) (SASTQueryCollection, error) {
-	c.config.Logger.Debugf("Get all queries for %v %v", level, levelId)
+	c.config.Logger.Debugf("Get all audit queries for %v %v", level, levelId)
 
 	collection := SASTQueryCollection{}
-	querytree, err := c.getAuditQueryTreeByLevelID(auditSession, level, levelId)
+	querytree, err := c.getAuditQueryTreeByLevelID(auditSession, level)
 	if err != nil {
 		return collection, err
 	}
 
-	collection.AddQueryTree(&querytree, auditSession.ApplicationID, levelId, false)
+	collection.AddQueryTree(&querytree, auditSession.ApplicationID, auditSession.ProjectID)
 
 	return collection, nil
 }
@@ -471,26 +485,26 @@ func (c *Cx1Client) GetAuditIACQueriesByLevelID(auditSession *AuditSession, leve
 	c.config.Logger.Debugf("Get all queries for %v %v", level, levelId)
 
 	collection := IACQueryCollection{}
-	querytree, err := c.getAuditQueryTreeByLevelID(auditSession, level, levelId)
+	querytree, err := c.getAuditQueryTreeByLevelID(auditSession, level)
 	if err != nil {
 		return collection, err
 	}
 
-	collection.AddQueryTree(&querytree, auditSession.ApplicationID, levelId)
+	collection.AddQueryTree(&querytree, auditSession.ApplicationID, auditSession.ProjectID)
 
 	return collection, nil
 }
 
-func (c *Cx1Client) getAuditQueryTreeByLevelID(auditSession *AuditSession, level, levelId string) ([]AuditQueryTree, error) {
+func (c *Cx1Client) getAuditQueryTreeByLevelID(auditSession *AuditSession, level string) ([]AuditQueryTree, error) {
 	var url string
 	var querytree []AuditQueryTree
 	switch level {
-	case AUDIT_QUERY.TENANT, AUDIT_QUERY.PRODUCT:
-		url = fmt.Sprintf("/query-editor/sessions/%v/queries", auditSession.ID)
-	case AUDIT_QUERY.PROJECT:
-		url = fmt.Sprintf("/query-editor/sessions/%v/queries?projectId=%v", auditSession.ID, levelId)
+	case AUDIT_QUERY.TENANT, AUDIT_QUERY.PRODUCT, AUDIT_QUERY.APPLICATION, AUDIT_QUERY.PROJECT:
+		url = fmt.Sprintf("/query-editor/sessions/%s/queries?level=%s", auditSession.ID, strings.ToLower(level))
+	case "": // special case to get all queries, regardless of level
+		url = fmt.Sprintf("/query-editor/sessions/%s/queries", auditSession.ID)
 	default:
-		return querytree, fmt.Errorf("invalid level %v, options are currently: %v, %v or %v", level, AUDIT_QUERY.PRODUCT, AUDIT_QUERY.TENANT, AUDIT_QUERY.PROJECT)
+		return querytree, fmt.Errorf("invalid level %s, options are currently: %s, %s, %s or %s", level, AUDIT_QUERY.PRODUCT, AUDIT_QUERY.TENANT, AUDIT_QUERY.APPLICATION, AUDIT_QUERY.PROJECT)
 	}
 
 	response, err := c.sendRequest(http.MethodGet, url, nil, nil)
@@ -555,7 +569,6 @@ func (c *Cx1Client) CreateSASTQueryOverride(auditSession *AuditSession, level st
 
 	newQueryData := NewQuery{
 		CWE:         baseQuery.CweID,
-		Executable:  baseQuery.IsExecutable,
 		Description: baseQuery.QueryDescriptionId,
 		Language:    baseQuery.Language,
 		Group:       baseQuery.Group,
@@ -565,6 +578,12 @@ func (c *Cx1Client) CreateSASTQueryOverride(auditSession *AuditSession, level st
 		Name:        baseQuery.Name,
 		Level:       strings.ToLower(level), // seems to be in lowercase in the post
 		Path:        baseQuery.Path,
+	}
+
+	if baseQuery.IsExecutable == nil {
+		newQueryData.Executable = true
+	} else {
+		newQueryData.Executable = *baseQuery.IsExecutable
 	}
 
 	jsonBody, _ := json.Marshal(newQueryData)
@@ -720,7 +739,6 @@ func (c *Cx1Client) CreateNewSASTQuery(auditSession *AuditSession, query SASTQue
 		Language:    query.Language,
 		Group:       query.Group,
 		Severity:    query.Severity,
-		Executable:  query.IsExecutable,
 		CWE:         query.CweID,
 		Description: query.QueryDescriptionId,
 	}
@@ -729,6 +747,11 @@ func (c *Cx1Client) CreateNewSASTQuery(auditSession *AuditSession, query SASTQue
 	}
 	if newQueryData.Description < 0 {
 		newQueryData.Description = 0
+	}
+	if query.IsExecutable == nil {
+		return SASTQuery{}, []QueryRunFailure{}, fmt.Errorf("Attempt to create new query %s with undefined isExecutable flag", query.StringDetailed())
+	} else {
+		newQueryData.Executable = *query.IsExecutable
 	}
 
 	var queryFail []QueryRunFailure
@@ -834,6 +857,10 @@ func (c *Cx1Client) CreateNewIACQuery(auditSession *AuditSession, query IACQuery
 
 func (c *Cx1Client) updateSASTQueryMetadataByKey(auditSession *AuditSession, queryKey string, metadata AuditSASTQueryMetadata) error {
 	c.config.Logger.Debugf("Updating sast query metadata by key: %v", queryKey)
+
+	if metadata.IsExecutable == nil {
+		return fmt.Errorf("attempt to save query with key %s and undefined IsExecutable flag", queryKey)
+	}
 	jsonBody, err := json.Marshal(metadata)
 	if err != nil {
 		return err

--- a/audit_test.go
+++ b/audit_test.go
@@ -66,7 +66,7 @@ func TestGetAuditSASTQueriesByLevelID(t *testing.T) {
 	}
 
 	var collection SASTQueryCollection
-	collection.AddQueryTree(&querytree, "", "", false)
+	collection.AddQueryTree(&querytree, "", "")
 
 	query := collection.GetQueryByLevelAndName("Cx", "Cx", "JavaScript", "JavaScript_High_Risk", "Client_DOM_XSS")
 	if query == nil {

--- a/audit_v310.go
+++ b/audit_v310.go
@@ -22,7 +22,7 @@ type AuditQuery_v310 struct {
 	Language           string `json:"lang"`
 	Severity           string
 	Cwe                int64
-	IsExecutable       bool
+	IsExecutable       *bool
 	CxDescriptionId    int64
 	QueryDescriptionId string
 	Key                string

--- a/presets.go
+++ b/presets.go
@@ -235,7 +235,7 @@ func (c *Cx1Client) GetSASTPresetQueries() (SASTQueryCollection, error) {
 			return collection, err
 		}
 
-		collection.AddQueryTree(&querytree, "", "", true)
+		collection.AddQueryTree(&querytree, "", "")
 		return collection, nil
 	} else {
 		return c.GetPresetQueries_v330()
@@ -306,7 +306,7 @@ func (c *Cx1Client) GetSASTQueryFamilyContents(family string) (SASTQueryCollecti
 		return collection, err
 	}
 
-	collection.AddQueryTree(&tree, "", "", false)
+	collection.AddQueryTree(&tree, "", "")
 
 	return collection, nil
 }
@@ -515,7 +515,7 @@ func (p Preset) GetSASTQueryCollection(queries SASTQueryCollection) SASTQueryCol
 	for _, fam := range p.QueryFamilies {
 		for _, qid := range fam.QueryIDs {
 			u, _ := strconv.ParseUint(qid, 0, 64)
-			if query := queries.GetQueryByLevelAndID(AUDIT_QUERY.PRODUCT, AUDIT_QUERY.PRODUCT, u); query != nil && query.IsExecutable {
+			if query := queries.GetQueryByLevelAndID(AUDIT_QUERY.PRODUCT, AUDIT_QUERY.PRODUCT, u); query != nil {
 				coll.AddQuery(*query)
 			}
 		}

--- a/presets_v330.go
+++ b/presets_v330.go
@@ -265,7 +265,7 @@ func (c *Cx1Client) GetPresetQueries_v330() (SASTQueryCollection, error) {
 	}
 
 	for i := range queries {
-		queries[i].IsExecutable = true // all queries in the preset are executable
+		queries[i].IsExecutable = boolPtr(true) // all queries in the preset are executable
 
 		if queries[i].Custom {
 			queries[i].Level = c.QueryTypeTenant()

--- a/queries.go
+++ b/queries.go
@@ -30,7 +30,7 @@ type AuditQuery_v312 struct {
 	Language           string `json:"lang"`
 	Severity           string
 	Cwe                int64
-	IsExecutable       bool
+	IsExecutable       *bool
 	CxDescriptionId    int64
 	QueryDescriptionId string
 	Key                string
@@ -217,7 +217,9 @@ func (q *SASTQuery) MergeQuery(nq SASTQuery) {
 	if q.Source == "" && nq.Source != "" {
 		q.Source = nq.Source
 	}
-	q.IsExecutable = nq.IsExecutable
+	if nq.IsExecutable != nil {
+		q.IsExecutable = nq.IsExecutable
+	}
 	if q.CweID == 0 && nq.CweID != 0 {
 		q.CweID = nq.CweID
 	}
@@ -334,8 +336,25 @@ func (q SASTQuery) GetMetadataDiffs(metadata AuditSASTQueryMetadata) []string {
 	}
 
 	if q.IsExecutable != metadata.IsExecutable {
-		diffs = append(diffs,
-			fmt.Sprintf("IsExecutable: %t != %t", q.IsExecutable, metadata.IsExecutable))
+		qexecStr := "undefined"
+		metaexecStr := "undefined"
+
+		if q.IsExecutable != nil {
+			if *q.IsExecutable {
+				qexecStr = "TRUE"
+			} else {
+				qexecStr = "FALSE"
+			}
+		}
+		if metadata.IsExecutable != nil {
+			if *metadata.IsExecutable {
+				metaexecStr = "TRUE"
+			} else {
+				metaexecStr = "FALSE"
+			}
+		}
+
+		diffs = append(diffs, fmt.Sprintf("IsExecutable: %s != %s", qexecStr, metaexecStr))
 	}
 
 	if q.QueryDescriptionId != metadata.CxDescriptionID {

--- a/results.go
+++ b/results.go
@@ -171,6 +171,16 @@ func (c *Cx1Client) AddIACResultsPredicates(predicates []IACResultsPredicates) e
 func (c *Cx1Client) GetSASTResultsPredicatesByID(SimilarityID string, ProjectID, ScanID string) ([]SASTResultsPredicates, error) {
 	c.config.Logger.Debugf("Fetching SAST results predicates for project %v scan %v similarityId %v", ProjectID, ScanID, SimilarityID)
 
+	return c.GetSASTResultsPredicatesFiltered(SASTResultsPredicatesFilter{
+		SimilarityID: SimilarityID,
+		ProjectIDs:   []string{ProjectID},
+		ScanID:       &ScanID,
+	})
+}
+
+func (c *Cx1Client) GetSASTResultsPredicatesFiltered(filter SASTResultsPredicatesFilter) ([]SASTResultsPredicates, error) {
+	params, _ := query.Values(filter)
+
 	var Predicates struct {
 		PredicateHistoryPerProject []struct {
 			ProjectID    string
@@ -181,7 +191,7 @@ func (c *Cx1Client) GetSASTResultsPredicatesByID(SimilarityID string, ProjectID,
 
 		TotalCount uint
 	}
-	response, err := c.sendRequest(http.MethodGet, fmt.Sprintf("/sast-results-predicates/%v?project-ids=%v&scan-id=%v", SimilarityID, ProjectID, ScanID), nil, nil)
+	response, err := c.sendRequest(http.MethodGet, fmt.Sprintf("/sast-results-predicates/%v?%s", filter.SimilarityID, params.Encode()), nil, nil)
 	if err != nil {
 		return []SASTResultsPredicates{}, err
 	}
@@ -196,6 +206,7 @@ func (c *Cx1Client) GetSASTResultsPredicatesByID(SimilarityID string, ProjectID,
 	}
 
 	return Predicates.PredicateHistoryPerProject[0].Predicates, err
+
 }
 
 func (c *Cx1Client) GetLastSASTResultsPredicateByID(SimilarityID string, ProjectID, ScanID string) (SASTResultsPredicates, error) {
@@ -485,7 +496,11 @@ func (c *Cx1Client) parseScanResults(scanId string, response []byte) (uint64, Sc
 }
 
 func (b ResultsPredicatesBase) String() string {
-	return fmt.Sprintf("[%v] %v set severity %v, state %v, comment %v", b.CreatedAt, b.CreatedBy, b.Severity, b.State, b.Comment)
+	var createdAt interface{} = "unknown"
+	if b.CreatedAt != nil {
+		createdAt = *b.CreatedAt
+	}
+	return fmt.Sprintf("[%v] %v set severity %v, state %v, comment %v", createdAt, b.CreatedBy, b.Severity, b.State, b.Comment)
 }
 
 func (c *Cx1Client) GetCustomResultStates() ([]ResultState, error) {
@@ -590,16 +605,12 @@ func (c *Cx1Client) GetResultsChangeHistoryFiltered(filter ResultsChangeFilter) 
 
 	// response.TotalSimilarityIds contains something like: "presenting 10 of 29"
 	var count, total uint64
-	if filter.EntityType == "similarityID" {
-		count = 1
-		total = 1
-	} else {
-		_, err = fmt.Sscanf(response.TotalSimilarityIds, "presenting %d of %d", &count, &total)
-		if err != nil {
-			// If parsing fails, we might not have the total, but we can return what we have.
-			// The API might change its format.
-			c.config.Logger.Warnf("Could not parse TotalSimilarityIds string: '%s'", response.TotalSimilarityIds)
-		}
+
+	_, err = fmt.Sscanf(response.TotalSimilarityIds, "presenting %d of %d", &count, &total)
+	if err != nil {
+		// If parsing fails, we might not have the total, but we can return what we have.
+		// The API might change its format.
+		c.config.Logger.Warnf("Could not parse TotalSimilarityIds string: '%s'", response.TotalSimilarityIds)
 	}
 
 	return total, response.Results, nil

--- a/sastquerycollection.go
+++ b/sastquerycollection.go
@@ -361,7 +361,7 @@ func (qc *SASTQueryCollection) AddQueries(queries *[]SASTQuery) {
 	}
 }
 
-func (qc *SASTQueryCollection) AddQueryTree(t *[]AuditQueryTree, appId, projectId string, setExecutable bool) {
+func (qc *SASTQueryCollection) AddQueryTree(t *[]AuditQueryTree, appId, projectId string) {
 	for _, lang := range *t {
 		for _, level := range lang.Children {
 			isCustom := true
@@ -411,7 +411,6 @@ func (qc *SASTQueryCollection) AddQueryTree(t *[]AuditQueryTree, appId, projectI
 						Language:           lang.Title,
 						Severity:           GetSeverity(GetSeverityID(query.Data.Severity)),
 						CweID:              query.Data.CWE,
-						IsExecutable:       setExecutable,
 						QueryDescriptionId: 0,
 						Custom:             isCustom,
 						EditorKey:          key,
@@ -538,7 +537,7 @@ func (qc SASTQueryCollection) GetQueryFamilies(executableOnly bool) []QueryFamil
 						query := &group.Queries[qid]
 						queryId := fmt.Sprintf("%d", query.QueryID)
 
-						if !slices.Contains(queryFamilies[id].QueryIDs, queryId) && (!executableOnly || query.IsExecutable) {
+						if !slices.Contains(queryFamilies[id].QueryIDs, queryId) && (!executableOnly || (query.IsExecutable != nil && *query.IsExecutable)) {
 							queryFamilies[id].QueryIDs = append(queryFamilies[id].QueryIDs, queryId)
 						}
 					}
@@ -556,7 +555,7 @@ func (qc SASTQueryCollection) GetQueryFamilies(executableOnly bool) []QueryFamil
 					query := &group.Queries[qid]
 					queryId := fmt.Sprintf("%d", query.QueryID)
 
-					if !slices.Contains(newFam.QueryIDs, queryId) && (!executableOnly || query.IsExecutable) {
+					if !slices.Contains(newFam.QueryIDs, queryId) && (!executableOnly || (query.IsExecutable != nil && *query.IsExecutable)) {
 						newFam.QueryIDs = append(newFam.QueryIDs, queryId)
 					}
 				}

--- a/sastresults.go
+++ b/sastresults.go
@@ -78,6 +78,10 @@ func (c *Cx1Client) GetScanSASTResultsFiltered(filter ScanSASTResultsFilter) (ui
 		ProjectID       string
 		ScanID          string
 		SourceFileName  string
+		AttackVectorID  string                       `json:"attackVectorID"`
+		IsAiGenerated   bool                         `json:"isAiGenerated"`
+		ChangedBy       string                       `json:"changedBy"`
+		ChangeDetails   *ScanSASTResultChangeDetails `json:"changeDetails"`
 	}
 
 	var results []ScanSASTResult
@@ -119,6 +123,7 @@ func (c *Cx1Client) GetScanSASTResultsFiltered(filter ScanSASTResultsFilter) (ui
 			},
 			Data: ScanSASTResultData{
 				QueryID:      r.QueryID,
+				QueryIDStr:   r.QueryIDStr,
 				QueryName:    r.QueryName,
 				Group:        r.Group,
 				ResultHash:   r.ResultHash,
@@ -126,8 +131,12 @@ func (c *Cx1Client) GetScanSASTResultsFiltered(filter ScanSASTResultsFilter) (ui
 				Nodes:        r.Nodes,
 			},
 			VulnerabilityDetails: ScanSASTResultDetails{
-				CweId:       r.CweID,
-				Compliances: r.Compliances,
+				CweId:          r.CweID,
+				Compliances:    r.Compliances,
+				AttackVectorID: r.AttackVectorID,
+				IsAiGenerated:  r.IsAiGenerated,
+				ChangedBy:      r.ChangedBy,
+				ChangeDetails:  r.ChangeDetails,
 			},
 		})
 	}

--- a/types.go
+++ b/types.go
@@ -1735,6 +1735,7 @@ type SCMRepository struct {
 	Scm                   struct {
 		TypeName string `json:"typeName"`
 	} `json:"scm"`
+	OrgID             int  `json:"orgId"`
 	ScaAutoPrEnabled  bool `json:"scaAutoPrEnabled"`
 	KicsAutoPrEnabled bool `json:"kicsAutoPrEnabled"`
 	SastAutoPrEnabled bool `json:"sastAutoPrEnabled"`

--- a/types.go
+++ b/types.go
@@ -766,10 +766,15 @@ type Project struct {
 	originalApplications []string               `json:"-"` // Cx1clientgo internal/restricted, do not change
 	Tags                 map[string]string      `json:"tags"`
 	RepoUrl              string                 `json:"repoUrl"`
+	RepoID               uint64                 `json:"repoId"`
+	SCMRepoID            string                 `json:"scmRepoId"`
+	ImportedProjectName  string                 `json:"imported_proj_name"`
 	MainBranch           string                 `json:"mainBranch"`
 	Origin               string                 `json:"origin"`
 	Criticality          uint                   `json:"criticality"`
 	Configuration        []ConfigurationSetting `json:"-"`
+	PrivatePackage       bool                   `json:"privatePackage"`
+	TenantID             string                 `json:"tenantId"`
 }
 
 type ProjectPatch struct {

--- a/types.go
+++ b/types.go
@@ -1339,7 +1339,10 @@ type ScanContainersResultDetails struct {
 
 type ScanIACResult struct {
 	ScanResultBase
-	Data ScanIACResultData
+	Data                 ScanIACResultData
+	VulnerabilityDetails struct {
+		CweId int `json:"cweId,string"`
+	}
 }
 type ScanIACResultData struct {
 	QueryID       string

--- a/types.go
+++ b/types.go
@@ -399,14 +399,14 @@ type AuditSASTQuery struct {
 	Key      string `json:"id"`
 	Name     string
 	Level    string
-	LevelID  string
+	LevelID  string `json:"-"` // used internally by cx1clientgo
 	Path     string
 	Source   string
-	Metadata AuditSASTQueryMetadata
+	Metadata AuditSASTQueryMetadata // nil unless explicitly requested
 }
 type AuditSASTQueryMetadata struct {
 	Cwe             int64  `json:"cwe,omitempty"`
-	IsExecutable    bool   `json:"executable"`
+	IsExecutable    *bool  `json:"executable,omitempty"`
 	CxDescriptionID int64  `json:"description,omitempty"`
 	Language        string `json:"language"`
 	Group           string `json:"group"`
@@ -1110,7 +1110,7 @@ type SASTQuery struct {
 	Language           string `json:"language"`
 	Severity           string `json:"severity"`
 	CweID              int64  `json:"cweID"`
-	IsExecutable       bool   `json:"isExecutable"`
+	IsExecutable       *bool  `json:"isExecutable,omitempty"`
 	QueryDescriptionId int64  `json:"queryDescriptionId"`
 	Custom             bool   `json:"custom"`
 	EditorKey          string `json:"key"`

--- a/types.go
+++ b/types.go
@@ -304,23 +304,25 @@ type Application struct {
 type ApplicationPatch struct {
 	Name        *string            `json:"name,omitempty"`
 	Description *string            `json:"description,omitempty"`
+	Type        *string            `json:"type,omitempty"`
 	Criticality *uint              `json:"criticality,omitempty"`
 	Tags        *map[string]string `json:"tags,omitempty"`
 }
 
 type ApplicationFilter struct {
 	BaseFilter
-	Name       string   `url:"name,omitempty"`
-	TagsKeys   []string `url:"tags-keys,omitempty"`
-	TagsValues []string `url:"tags-values,omitempty"`
+	Name           string   `url:"name,omitempty"`
+	TagsKeys       []string `url:"tags-keys,omitempty"`
+	TagsValues     []string `url:"tags-values,omitempty"`
+	ApplicationIDs []string `url:"application-ids,omitempty"` // max 200 IDs per spec
 }
 
 type ApplicationAMFilter struct {
 	BaseFilter
 	Action     string   `url:"action"`
 	Name       string   `url:"name"`
-	TagsKeys   []string `url:"tagsKeys"`
-	TagsValues []string `url:"tagsValues"`
+	TagsKeys   []string `url:"tags-keys"`
+	TagsValues []string `url:"tags-values"`
 }
 
 type ApplicationRule struct {
@@ -573,6 +575,10 @@ type Group struct {
 	ClientRoles     map[string][]string `json:"clientRoles"`
 	RealmRoles      []string            `json:"realmRoles"`
 	Filled          bool                `json:"-"`
+	// Access Management (/access-management/groups) response-only fields:
+	BriefName  string                 `json:"briefName,omitempty"`
+	Roles      []string               `json:"roles,omitempty"`
+	Attributes map[string]interface{} `json:"attributes,omitempty"`
 }
 
 type GroupFilter struct {
@@ -661,7 +667,7 @@ type OIDCClientFilter struct {
 }
 type OIDCClientAMFilter struct {
 	BaseFilter
-	Search string `json:"search"`
+	Search string `url:"search,omitempty"`
 }
 
 // Access Management phase2
@@ -778,12 +784,15 @@ type Project struct {
 }
 
 type ProjectPatch struct {
-	Name        *string            `json:"name,omitempty"`
-	RepoUrl     *string            `json:"repoUrl,omitempty"`
-	MainBranch  *string            `json:"mainBranch,omitempty"`
-	Criticality *uint              `json:"criticality,omitempty"`
-	Tags        *map[string]string `json:"tags,omitempty"`
-	Groups      *[]string          `json:"groups,omitempty"`
+	Name           *string            `json:"name,omitempty"`
+	RepoUrl        *string            `json:"repoUrl,omitempty"`
+	MainBranch     *string            `json:"mainBranch,omitempty"`
+	Criticality    *uint              `json:"criticality,omitempty"`
+	Tags           *map[string]string `json:"tags,omitempty"`
+	Groups         *[]string          `json:"groups,omitempty"`
+	PrivatePackage *bool              `json:"privatePackage,omitempty"`
+	//SCMRepoID      *string            `json:"scmRepoId,omitempty"`
+	//RepoID         *uint64            `json:"repoId,omitempty"`
 }
 
 type ProjectFilter struct {
@@ -805,8 +814,8 @@ type ProjectAMFilter struct {
 	BaseFilter
 	Action     string   `url:"action"`
 	Name       string   `url:"name"`
-	TagsKeys   []string `url:"tagsKeys"`
-	TagsValues []string `url:"tagsValues"`
+	TagsKeys   []string `url:"tags-keys"`
+	TagsValues []string `url:"tags-values"`
 }
 
 type ProjectBranchFilter struct {
@@ -862,12 +871,15 @@ type ProjectScanSchedule struct {
 	ID            string            `json:"id"`
 	Name          string            `json:"name"`
 	ProjectID     string            `json:"projectID"`
+	ProjectName   string            `json:"project_name,omitempty"`
+	ProjectType   string            `json:"project_type,omitempty"` // scm or manual
 	NextStartTime time.Time         `json:"start_time"`
 	StartTime     string            `json:"-"`
-	CreatedAt     time.Time         `json:"create_at"`
-	UpdatedAt     time.Time         `json:"update_at"`
-	Frequency     string            `json:"frequency"`      // weekly or daily
-	Days          []string          `json:"days,omitempty"` // monday, tuesday ... iff weekly
+	CreatedAt     time.Time         `json:"created_at"`
+	UpdatedAt     time.Time         `json:"updated_at"`
+	TriggerTime   time.Time         `json:"trigger_time,omitempty"` // last trigger time
+	Frequency     string            `json:"frequency"`              // weekly or daily
+	Days          []string          `json:"days,omitempty"`         // monday, tuesday ... iff weekly
 	Active        bool              `json:"active"`
 	Engines       []string          `json:"engines"`
 	Branch        string            `json:"branch"`
@@ -876,7 +888,7 @@ type ProjectScanSchedule struct {
 
 type ProjectScanScheduleFilter struct {
 	BaseFilter
-	Search           string     `url:"string,omitempty"`
+	Search           string     `url:"search,omitempty"`
 	Name             string     `url:"name,omitempty"`
 	Active           *bool      `url:"active,omitempty"`
 	Frequency        []string   `url:"frequency,omitempty"`
@@ -1000,23 +1012,41 @@ type ResultsChangeFilter struct {
 type ResultsChangeHistory struct {
 	SimilarityID string             `json:"similarityId"`
 	Predicates   []ResultsChangelog `json:"predicates"`
+	TotalCount   uint               `json:"totalCount"`
 }
 type ResultsChangelog struct {
 	Change string    `json:"change"`
 	Date   time.Time `json:"date"`
 	User   string    `json:"user"`
+	Origin string    `json:"origin,omitempty"`
+}
+
+type Cx1CommentTime struct {
+	time.Time
 }
 
 type ResultsPredicatesBase struct {
-	PredicateID  string    `json:"ID,omitempty"`
-	SimilarityID string    `json:"similarityId"`
-	ProjectID    string    `json:"projectId"`
-	ScanID       string    `json:"scanId"`
-	State        string    `json:"state,omitempty"`
-	Comment      string    `json:"comment"`
-	Severity     string    `json:"severity,omitempty"`
-	CreatedBy    string    `json:"createdBy,omitempty"`
-	CreatedAt    time.Time `json:"createdAt,omitempty"`
+	PredicateID   string     `json:"ID,omitempty"`
+	SimilarityID  string     `json:"similarityId"`
+	ProjectID     string     `json:"projectId"`
+	ScanID        string     `json:"scanId"`
+	State         string     `json:"state,omitempty"`
+	Comment       string     `json:"comment"`
+	Severity      string     `json:"severity,omitempty"`
+	CustomStateID *uint64    `json:"customStateId,omitempty"`
+	CreatedBy     string     `json:"createdBy,omitempty"`
+	CreatedAt     *time.Time `json:"createdAt,omitempty"` // pointer so omitempty actually suppresses it when unset (encoding/json's omitempty has no effect on a zero-value time.Time)
+	CommentJSON   struct {
+		ID        string         `json:"id"`
+		Comment   string         `json:"content"`
+		CreatedAt Cx1CommentTime `json:"date"`
+		CreatedBy string         `json:"user"`
+		IsDeleted bool           `json:"isDeleted"`
+	} `json:"commentJSON,omitempty"`
+	ChangeOriginType uint64 `json:"changeOriginType,omitempty"`
+	ChangeOriginName string `json:"changeOriginName,omitempty"`
+	ChangedBy        string `json:"changedBy,omitempty"`
+	TriggeredBy      string `json:"triggeredBy,omitempty"`
 }
 
 type ResultState struct {
@@ -1046,7 +1076,7 @@ type Role struct {
 // Access Management Phase 2
 type AMRole struct {
 	ID                  string    `json:"id"`
-	TenantID            string    `json:"tenantId"`
+	TenantID            string    `json:"tenantID"`
 	Name                string    `json:"name"`
 	Description         string    `json:"description"`
 	SystemRole          bool      `json:"systemRole"`
@@ -1126,6 +1156,14 @@ type IACResultsPredicates struct {
 	ResultsPredicatesBase // actually the same structure but different endpoint
 }
 
+type SASTResultsPredicatesFilter struct {
+	SimilarityID       string   `url:"-"`
+	ProjectIDs         []string `url:"project-ids,omitempty"`
+	IncludeCommentJSON *bool    `url:"include-comment-json,omitempty"`
+	IncludeChangedBy   *bool    `url:"include-changed-by,omitempty"`
+	ScanID             *string  `url:"scan-id,omitempty"`
+}
+
 /*
 type KeyCloakClient struct {
 	ClientID string `json:"id"`
@@ -1174,18 +1212,22 @@ type SASTAggregateSummaryFilter struct {
 }
 
 type Scan struct {
-	ScanID        string              `json:"id"`
-	Status        string              `json:"status"`
-	StatusDetails []ScanStatusDetails `json:"statusDetails"`
-	Branch        string              `json:"branch"`
-	CreatedAt     time.Time           `json:"createdAt"`
-	UpdatedAt     time.Time           `json:"updatedAt"`
-	ProjectID     string              `json:"projectId"`
-	ProjectName   string              `json:"projectName"`
-	UserAgent     string              `json:"userAgent"`
-	Initiator     string              `json:"initiator"`
-	Tags          map[string]string   `json:"tags"`
-	Metadata      struct {
+	ScanID          string              `json:"id"`
+	Status          string              `json:"status"`
+	StatusDetails   []ScanStatusDetails `json:"statusDetails"`
+	PositionInQueue uint64              `json:"positionInQueue,omitempty"`
+	Branch          string              `json:"branch"`
+	CommitID        string              `json:"commitId,omitempty"`
+	CommitTag       string              `json:"commitTag,omitempty"`
+	UploadURL       string              `json:"uploadUrl,omitempty"`
+	CreatedAt       time.Time           `json:"createdAt"`
+	UpdatedAt       time.Time           `json:"updatedAt"`
+	ProjectID       string              `json:"projectId"`
+	ProjectName     string              `json:"projectName"`
+	UserAgent       string              `json:"userAgent"`
+	Initiator       string              `json:"initiator"`
+	Tags            map[string]string   `json:"tags"`
+	Metadata        struct {
 		Type    string              `json:"type"`
 		Configs []ScanConfiguration `json:"configs"`
 		Handler struct {
@@ -1204,13 +1246,22 @@ type Scan struct {
 
 type ScanFilter struct {
 	BaseFilter
-	ProjectID     string    `url:"project-id"`
+	ProjectID     string    `url:"project-id,omitempty"`
+	ProjectIDs    []string  `url:"project-ids,omitempty"`
+	ProjectNames  []string  `url:"project-names,omitempty"`
+	ScanIDs       []string  `url:"scan-ids,omitempty"`
+	Groups        []string  `url:"groups,omitempty"`
 	Sort          []string  `url:"sort,omitempty"` // Available values : -created_at, +created_at, -status, +status, +branch, -branch, +initiator, -initiator, +user_agent, -user_agent, +name, -name
 	TagKeys       []string  `url:"tags-keys,omitempty"`
 	TagValues     []string  `url:"tags-values,omitempty"`
 	Statuses      []string  `url:"statuses,omitempty"`
+	Branch        string    `url:"branch,omitempty"` // singular, legacy filter
 	Branches      []string  `url:"branches,omitempty"`
+	SourceTypes   []string  `url:"source-types,omitempty"`
 	SourceOrigins []string  `url:"source-origins,omitempty"` // "Github Action", "webapp" etc
+	Initiators    []string  `url:"initiators,omitempty"`
+	Field         string    `url:"field,omitempty"`
+	Search        string    `url:"search,omitempty"`
 	FromDate      time.Time `url:"from-date,omitempty"`
 	ToDate        time.Time `url:"to-date,omitempty"`
 }
@@ -1225,10 +1276,12 @@ type ScanConfigurationSet struct {
 }
 
 type ScanHandler struct {
-	RepoURL     string                 `json:"repoUrl"`
-	Branch      string                 `json:"branch"`
-	Commit      string                 `json:"commit"`
-	Credentials map[string]interface{} `json:"credentials"`
+	RepoURL        string                 `json:"repoUrl"`
+	Branch         string                 `json:"branch"`
+	Commit         string                 `json:"commit,omitempty"`
+	Tag            string                 `json:"tag,omitempty"`
+	SkipSubModules bool                   `json:"skipSubModules,omitempty"`
+	Credentials    map[string]interface{} `json:"credentials"`
 }
 
 type ScanMetadata struct {
@@ -1364,6 +1417,7 @@ type ScanSASTResult struct {
 }
 type ScanSASTResultData struct {
 	QueryID      uint64
+	QueryIDStr   string
 	QueryName    string
 	Group        string
 	ResultHash   string
@@ -1384,46 +1438,83 @@ type ScanSASTResultNodes struct {
 	TypeName    string
 	MethodLine  uint64
 	Definitions string
+	NodeHash    string `json:"nodeHash,omitempty"` // documented replacement for the deprecated nodeSystemID
 }
 type ScanSASTResultDetails struct {
-	CweId       int
-	Compliances []string
+	CweId          int
+	Compliances    []string
+	AttackVectorID string                       `json:"attackVectorID,omitempty"`
+	IsAiGenerated  bool                         `json:"isAiGenerated,omitempty"`
+	ChangedBy      string                       `json:"changedBy,omitempty"`
+	ChangeDetails  *ScanSASTResultChangeDetails `json:"changeDetails,omitempty"`
+}
+
+// ScanSASTResultChangeDetails describes why a result reappeared (engine/query/code change).
+type ScanSASTResultChangeDetails struct {
+	EngineVersionChanged       bool   `json:"engineVersionChanged"`
+	EngineVersionChangeDetails string `json:"engineVersionChangeDetails,omitempty"`
+	QueryChanged               bool   `json:"queryChanged"`
+	QueryChangeDetails         string `json:"queryChangeDetails,omitempty"`
+	CodeChanged                bool   `json:"codeChanged"`
+	CodeChangeDetails          string `json:"codeChangeDetails,omitempty"`
 }
 
 type ScanSASTResultsFilter struct {
 	BaseFilter
-	ScanID                 string   `url:"scan-id"`
-	Language               []string `url:"language,omitempty"`
-	Status                 []string `url:"status,omitempty"`   //NEW, RECURRENT
-	Severity               []string `url:"severity,omitempty"` //CRITICAL, HIGH, MEDIUM, LOW, INFO
-	SourceFile             string   `url:"source-file,omitempty"`
-	SourceFileOperation    string   `url:"source-file-operation,omitempty"` // LESS_THAN, GREATER_THAN, EQUAL, NOT_EQUAL, CONTAINS, NOT_CONTAINS, START_WITH
-	SourceNode             string   `url:"source-node,omitempty"`
-	SourceNodeOperation    string   `url:"source-node-operation,omitempty"` // LESS_THAN, GREATER_THAN, EQUAL, NOT_EQUAL, CONTAINS, NOT_CONTAINS, START_WITH
-	SourceLine             uint64   `url:"source-line,omitempty"`
-	SourceLineOperation    string   `url:"source-line-operation,omitempty"` // LESS_THAN, GREATER_THAN, EQUAL, NOT_EQUAL
-	SinkFile               string   `url:"sink-file,omitempty"`
-	SinkFileOperation      string   `url:"sink-file-operation,omitempty"` // LESS_THAN, GREATER_THAN, EQUAL, NOT_EQUAL, CONTAINS, NOT_CONTAINS, START_WITH
-	SinkNode               string   `url:"sink-node,omitempty"`
-	SinkNodeOperation      string   `url:"sink-node-operation,omitempty"` // LESS_THAN, GREATER_THAN, EQUAL, NOT_EQUAL, CONTAINS, NOT_CONTAINS, START_WITH
-	SinkLine               uint64   `url:"sink-line,omitempty"`
-	SinkLineOperation      string   `url:"sink-line-operation,omitempty"` // LESS_THAN, GREATER_THAN, EQUAL, NOT_EQUAL
-	NumberOfNodes          uint64   `url:"number-of-nodes,omitempty"`
-	NumberOfNodesOperation string   `url:"number-of-nodes-operation,omitempty"` // LESS_THAN, GREATER_THAN, EQUAL, NOT_EQUAL
-	Notes                  string   `url:"notes,omitempty"`
-	NotesOperation         string   `url:"notes-operation,omitempty"` // CONTAINS, STARTS_WITH
-	FirstFoundAt           string   `url:"first-found-at,omitempty"`
-	FirstFoundAtOperation  string   `url:"first-found-at-operation,omitempty"` // LESS_THAN, GREATER_THAN
-	QueryIDs               []uint64 `url:"query-ids,omitempty"`
-	PresetID               uint64   `url:"preset-id,omitempty"`
-	ResultIDs              []string `url:"result-id,omitempty"`
-	Categories             string   `url:"category,omitempty"` // comma-separated list
-	Search                 string   `url:"search,omitempty"`
-	IncludeNodes           *bool    `url:"include-nodes,omitempty"`
-	ApplyPredicates        *bool    `url:"apply-predicates,omitempty"`
-	Sort                   []string `url:"sort,omitempty"` // Default value : +status,+severity,-queryname
-	VisibleColumns         []string `url:"visible-columns,omitempty"`
-	State                  []string `url:"state,omitempty"`
+	ScanID                   string   `url:"scan-id"`
+	Language                 []string `url:"language,omitempty"`
+	Status                   []string `url:"status,omitempty"`   //NEW, RECURRENT
+	Severity                 []string `url:"severity,omitempty"` //CRITICAL, HIGH, MEDIUM, LOW, INFO
+	SourceFile               string   `url:"source-file,omitempty"`
+	SourceFileOperation      string   `url:"source-file-operation,omitempty"` // LESS_THAN, GREATER_THAN, EQUAL, NOT_EQUAL, CONTAINS, NOT_CONTAINS, START_WITH
+	SourceNode               string   `url:"source-node,omitempty"`
+	SourceNodeOperation      string   `url:"source-node-operation,omitempty"` // LESS_THAN, GREATER_THAN, EQUAL, NOT_EQUAL, CONTAINS, NOT_CONTAINS, START_WITH
+	SourceLine               uint64   `url:"source-line,omitempty"`
+	SourceLineOperation      string   `url:"source-line-operation,omitempty"` // LESS_THAN, GREATER_THAN, EQUAL, NOT_EQUAL
+	SinkFile                 string   `url:"sink-file,omitempty"`
+	SinkFileOperation        string   `url:"sink-file-operation,omitempty"` // LESS_THAN, GREATER_THAN, EQUAL, NOT_EQUAL, CONTAINS, NOT_CONTAINS, START_WITH
+	SinkNode                 string   `url:"sink-node,omitempty"`
+	SinkNodeOperation        string   `url:"sink-node-operation,omitempty"` // LESS_THAN, GREATER_THAN, EQUAL, NOT_EQUAL, CONTAINS, NOT_CONTAINS, START_WITH
+	SinkLine                 uint64   `url:"sink-line,omitempty"`
+	SinkLineOperation        string   `url:"sink-line-operation,omitempty"` // LESS_THAN, GREATER_THAN, EQUAL, NOT_EQUAL
+	NumberOfNodes            uint64   `url:"number-of-nodes,omitempty"`
+	NumberOfNodesOperation   string   `url:"number-of-nodes-operation,omitempty"` // LESS_THAN, GREATER_THAN, EQUAL, NOT_EQUAL
+	Notes                    string   `url:"notes,omitempty"`
+	NotesOperation           string   `url:"notes-operation,omitempty"` // CONTAINS, STARTS_WITH
+	FirstFoundAt             string   `url:"first-found-at,omitempty"`
+	FirstFoundAtOperation    string   `url:"first-found-at-operation,omitempty"` // LESS_THAN, GREATER_THAN
+	QueryIDs                 []uint64 `url:"query-ids,omitempty"`
+	PresetID                 uint64   `url:"preset-id,omitempty"`
+	ResultIDs                []string `url:"result-id,omitempty"`
+	Categories               string   `url:"category,omitempty"` // comma-separated list
+	Search                   string   `url:"search,omitempty"`
+	IncludeNodes             *bool    `url:"include-nodes,omitempty"`
+	ApplyPredicates          *bool    `url:"apply-predicates,omitempty"`
+	Sort                     []string `url:"sort,omitempty"` // Default value : +status,+severity,-queryname
+	VisibleColumns           []string `url:"visible-columns,omitempty"`
+	State                    []string `url:"state,omitempty"`
+	Group                    string   `url:"group,omitempty"`
+	GroupOperation           string   `url:"group-operation,omitempty"`
+	Compliance               []string `url:"compliance,omitempty"`
+	BflName                  string   `url:"bfl-name,omitempty"`
+	BflNameOperation         string   `url:"bfl-name-operation,omitempty"`
+	BflGroupSize             uint64   `url:"bfl-group-size,omitempty"`
+	BflGroupSizeOperation    string   `url:"bfl-group-size-operation,omitempty"`
+	CweID                    []uint64 `url:"cwe-id,omitempty"`
+	CweIDOperation           string   `url:"cwe-id-operation,omitempty"`
+	Query                    string   `url:"query,omitempty"`
+	QueryOperation           string   `url:"query-operation,omitempty"`
+	NodeIDs                  []string `url:"node-ids,omitempty"`
+	SimilarityIDFilter       []string `url:"similarity-id,omitempty"`
+	SimilarityIDOperation    string   `url:"similarity-id-operation,omitempty"`
+	AttackVectorID           []string `url:"attack-vector-id,omitempty"`
+	AttackVectorIDOperation  string   `url:"attack-vector-id-operation,omitempty"`
+	ConfidenceLevel          []string `url:"confidence-level,omitempty"`
+	ConfidenceLevelOperation string   `url:"confidence-level-operation,omitempty"`
+	ConfidenceScore          float64  `url:"confidence-score,omitempty"`
+	ConfidenceScoreOperation string   `url:"confidence-score-operation,omitempty"`
+	IsAiGenerated            *bool    `url:"is-ai-generated,omitempty"`
+	IsAiGeneratedOperation   string   `url:"is-ai-generated-operation,omitempty"`
 }
 
 type ScanSCAResult struct {
@@ -1766,6 +1857,12 @@ type User struct {
 	FilledGroups bool        `json:"-"` // indicates if the user object has had the Groups array filled.
 	Roles        []Role      `json:"-"` // only returned from /users/{id}/role-mappings. Use GetUserRoles to fill.
 	FilledRoles  bool        `json:"-"` // indicates if the user object has had the Roles array filled.
+	// Access Management (/access-management/users) response-only fields:
+	EmailVerified    bool     `json:"emailVerified,omitempty"`
+	RequiredActions  []string `json:"requiredActions,omitempty"`
+	CreatedTimestamp uint64   `json:"createdTimestamp,omitempty"`
+	AMGroupIDs       []string `json:"groups,omitempty"` // group IDs/names as returned by Access Management; distinct from Groups above
+	AMRoleIDs        []string `json:"roles,omitempty"`  // role IDs/names as returned by Access Management; distinct from Roles above
 }
 
 type UserFilter struct {

--- a/types.go
+++ b/types.go
@@ -788,16 +788,17 @@ type ProjectPatch struct {
 
 type ProjectFilter struct {
 	BaseFilter
-	ProjectIDs []string `url:"ids,omitempty"`
-	Names      []string `url:"names,omitempty"`
-	Name       string   `url:"name,omitempty"`
-	NameRegex  string   `url:"name-regex,omitempty"`
-	Groups     []string `url:"groups,omitempty"`
-	Origins    []string `url:"origins,omitempty"`
-	TagsKeys   []string `url:"tags-keys,omitempty"`
-	TagsValues []string `url:"tags-values,omitempty"`
-	EmptyTags  *bool    `url:"empty-tags,omitempty"`
-	RepoURL    string   `url:"repo-url,omitempty"`
+	ProjectIDs       []string `url:"ids,omitempty"`
+	Names            []string `url:"names,omitempty"`
+	Name             string   `url:"name,omitempty"`
+	NameRegex        string   `url:"name-regex,omitempty"`
+	Groups           []string `url:"groups,omitempty"`
+	Origins          []string `url:"origins,omitempty"`
+	TagsKeys         []string `url:"tags-keys,omitempty"`
+	TagsValues       []string `url:"tags-values,omitempty"`
+	EmptyTags        *bool    `url:"empty-tags,omitempty"`
+	RepoURL          string   `url:"repo-url,omitempty"`
+	ImportedProjects *bool    `url:"imported-projects,omitempty"`
 }
 
 type ProjectAMFilter struct {

--- a/util.go
+++ b/util.go
@@ -80,3 +80,15 @@ func (ct *Cx1LongTime) UnmarshalJSON(b []byte) (err error) {
 	ct.Time, err = time.Parse(cx1TimeLayout, s)
 	return
 }
+
+const cx1CommentLayout = "2006-01-02 15:04:05.999999999 -0700 MST"
+
+func (ct *Cx1CommentTime) UnmarshalJSON(b []byte) (err error) {
+	s := strings.Trim(string(b), "\"")
+	if s == "null" {
+		ct.Time = time.Time{}
+		return
+	}
+	ct.Time, err = time.Parse(cx1CommentLayout, s)
+	return
+}


### PR DESCRIPTION
SASTQuery.IsExecutable was a bool, but was not always provided by the API, so now it is a *bool with default nil. Attempting to save a query with nil IsExecutable throws an error because it indicates that the query was not populated correctly.