### PR TITLE
Fix query executable defaults (#299)

### DIFF
--- a/_examples/AccessManagement/AccessManagement.go
+++ b/_examples/AccessManagement/AccessManagement.go
@@ -1,10 +1,8 @@
 package main
 
 import (
-	"crypto/tls"
 	"fmt"
 	"net/http"
-	"net/url"
 	"os"
 	"strings"
 
@@ -25,15 +23,6 @@ func main() {
 	logger.Infof("Starting")
 
 	httpClient := &http.Client{}
-	if true {
-		proxyURL, _ := url.Parse("http://127.0.0.1:8080")
-		transport := &http.Transport{}
-		transport.Proxy = http.ProxyURL(proxyURL)
-		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-		httpClient.Transport = transport
-		logger.Infof("Using proxy")
-	}
-
 	cx1client, err := Cx1ClientGo.NewClient(httpClient, logger)
 	if err != nil {
 		logger.Fatalf("Error creating client: %s", err)

--- a/_examples/QueryManipulation/QueryManipulation.go
+++ b/_examples/QueryManipulation/QueryManipulation.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-	"crypto/tls"
 	"net/http"
-	"net/url"
 	"os"
 
 	"github.com/cxpsemea/Cx1ClientGo"
@@ -27,14 +25,6 @@ func main() {
 	logger.Infof("Starting")
 
 	httpClient := &http.Client{}
-	if true {
-		proxyURL, _ := url.Parse("http://127.0.0.1:8080")
-		transport := &http.Transport{}
-		transport.Proxy = http.ProxyURL(proxyURL)
-		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-		httpClient.Transport = transport
-		logger.Infof("Using proxy")
-	}
 	cx1client, err := Cx1ClientGo.NewClient(httpClient, logger)
 	if err != nil {
 		logger.Fatalf("Error creating client: %s", err)
@@ -357,6 +347,7 @@ func newSASTProjectOverride(cx1client *Cx1ClientGo.Cx1Client, logger *logrus.Log
 
 func newSASTCorpQuery(cx1client *Cx1ClientGo.Cx1Client, logger *logrus.Logger, qc *Cx1ClientGo.SASTQueryCollection, session *Cx1ClientGo.AuditSession) *Cx1ClientGo.SASTQuery {
 	logger.Infof("Creating corp query under session %v", session.ID)
+	tb := true
 	NewQuery := Cx1ClientGo.SASTQuery{
 		Source:             "result = Find_Strings().FindByName(\"test\"); // new corp query",
 		Name:               "Test_String",
@@ -364,7 +355,7 @@ func newSASTCorpQuery(cx1client *Cx1ClientGo.Cx1Client, logger *logrus.Logger, q
 		Language:           "Java",
 		Severity:           "Low",
 		CweID:              123,
-		IsExecutable:       true,
+		IsExecutable:       &tb,
 		QueryDescriptionId: 123,
 	}
 

--- a/audit.go
+++ b/audit.go
@@ -437,6 +437,20 @@ func (c *Cx1Client) GetAuditIACQueryByID(auditSession *AuditSession, queryId str
 	return query, nil
 }
 
+func (c *Cx1Client) GetAllAuditSASTQueries(auditSession *AuditSession) (SASTQueryCollection, error) {
+	c.config.Logger.Debugf("Get all audit queries")
+
+	collection := SASTQueryCollection{}
+	querytree, err := c.getAuditQueryTreeByLevelID(auditSession, "")
+	if err != nil {
+		return collection, err
+	}
+
+	collection.AddQueryTree(&querytree, auditSession.ApplicationID, auditSession.ProjectID)
+
+	return collection, nil
+}
+
 /*
 Retrieves the list of queries available for this audit session. Level and LevelID options are:
 QueryTypeProduct(), QueryTypeProduct() : same value for both when retrieving product-default queries
@@ -446,15 +460,15 @@ QueryTypeProject(), project.ProjectID : when retrieving project-level queries (i
 The resulting array of queries should be merged into a QueryCollection object returned by the GetQueries function.
 */
 func (c *Cx1Client) GetAuditSASTQueriesByLevelID(auditSession *AuditSession, level, levelId string) (SASTQueryCollection, error) {
-	c.config.Logger.Debugf("Get all queries for %v %v", level, levelId)
+	c.config.Logger.Debugf("Get all audit queries for %v %v", level, levelId)
 
 	collection := SASTQueryCollection{}
-	querytree, err := c.getAuditQueryTreeByLevelID(auditSession, level, levelId)
+	querytree, err := c.getAuditQueryTreeByLevelID(auditSession, level)
 	if err != nil {
 		return collection, err
 	}
 
-	collection.AddQueryTree(&querytree, auditSession.ApplicationID, levelId, false)
+	collection.AddQueryTree(&querytree, auditSession.ApplicationID, auditSession.ProjectID)
 
 	return collection, nil
 }
@@ -471,26 +485,26 @@ func (c *Cx1Client) GetAuditIACQueriesByLevelID(auditSession *AuditSession, leve
 	c.config.Logger.Debugf("Get all queries for %v %v", level, levelId)
 
 	collection := IACQueryCollection{}
-	querytree, err := c.getAuditQueryTreeByLevelID(auditSession, level, levelId)
+	querytree, err := c.getAuditQueryTreeByLevelID(auditSession, level)
 	if err != nil {
 		return collection, err
 	}
 
-	collection.AddQueryTree(&querytree, auditSession.ApplicationID, levelId)
+	collection.AddQueryTree(&querytree, auditSession.ApplicationID, auditSession.ProjectID)
 
 	return collection, nil
 }
 
-func (c *Cx1Client) getAuditQueryTreeByLevelID(auditSession *AuditSession, level, levelId string) ([]AuditQueryTree, error) {
+func (c *Cx1Client) getAuditQueryTreeByLevelID(auditSession *AuditSession, level string) ([]AuditQueryTree, error) {
 	var url string
 	var querytree []AuditQueryTree
 	switch level {
-	case AUDIT_QUERY.TENANT, AUDIT_QUERY.PRODUCT:
-		url = fmt.Sprintf("/query-editor/sessions/%v/queries", auditSession.ID)
-	case AUDIT_QUERY.PROJECT:
-		url = fmt.Sprintf("/query-editor/sessions/%v/queries?projectId=%v", auditSession.ID, levelId)
+	case AUDIT_QUERY.TENANT, AUDIT_QUERY.PRODUCT, AUDIT_QUERY.APPLICATION, AUDIT_QUERY.PROJECT:
+		url = fmt.Sprintf("/query-editor/sessions/%s/queries?level=%s", auditSession.ID, strings.ToLower(level))
+	case "": // special case to get all queries, regardless of level
+		url = fmt.Sprintf("/query-editor/sessions/%s/queries", auditSession.ID)
 	default:
-		return querytree, fmt.Errorf("invalid level %v, options are currently: %v, %v or %v", level, AUDIT_QUERY.PRODUCT, AUDIT_QUERY.TENANT, AUDIT_QUERY.PROJECT)
+		return querytree, fmt.Errorf("invalid level %s, options are currently: %s, %s, %s or %s", level, AUDIT_QUERY.PRODUCT, AUDIT_QUERY.TENANT, AUDIT_QUERY.APPLICATION, AUDIT_QUERY.PROJECT)
 	}
 
 	response, err := c.sendRequest(http.MethodGet, url, nil, nil)
@@ -555,7 +569,6 @@ func (c *Cx1Client) CreateSASTQueryOverride(auditSession *AuditSession, level st
 
 	newQueryData := NewQuery{
 		CWE:         baseQuery.CweID,
-		Executable:  baseQuery.IsExecutable,
 		Description: baseQuery.QueryDescriptionId,
 		Language:    baseQuery.Language,
 		Group:       baseQuery.Group,
@@ -565,6 +578,12 @@ func (c *Cx1Client) CreateSASTQueryOverride(auditSession *AuditSession, level st
 		Name:        baseQuery.Name,
 		Level:       strings.ToLower(level), // seems to be in lowercase in the post
 		Path:        baseQuery.Path,
+	}
+
+	if baseQuery.IsExecutable == nil {
+		newQueryData.Executable = true
+	} else {
+		newQueryData.Executable = *baseQuery.IsExecutable
 	}
 
 	jsonBody, _ := json.Marshal(newQueryData)
@@ -720,7 +739,6 @@ func (c *Cx1Client) CreateNewSASTQuery(auditSession *AuditSession, query SASTQue
 		Language:    query.Language,
 		Group:       query.Group,
 		Severity:    query.Severity,
-		Executable:  query.IsExecutable,
 		CWE:         query.CweID,
 		Description: query.QueryDescriptionId,
 	}
@@ -729,6 +747,11 @@ func (c *Cx1Client) CreateNewSASTQuery(auditSession *AuditSession, query SASTQue
 	}
 	if newQueryData.Description < 0 {
 		newQueryData.Description = 0
+	}
+	if query.IsExecutable == nil {
+		return SASTQuery{}, []QueryRunFailure{}, fmt.Errorf("Attempt to create new query %s with undefined isExecutable flag", query.StringDetailed())
+	} else {
+		newQueryData.Executable = *query.IsExecutable
 	}
 
 	var queryFail []QueryRunFailure
@@ -834,6 +857,10 @@ func (c *Cx1Client) CreateNewIACQuery(auditSession *AuditSession, query IACQuery
 
 func (c *Cx1Client) updateSASTQueryMetadataByKey(auditSession *AuditSession, queryKey string, metadata AuditSASTQueryMetadata) error {
 	c.config.Logger.Debugf("Updating sast query metadata by key: %v", queryKey)
+
+	if metadata.IsExecutable == nil {
+		return fmt.Errorf("attempt to save query with key %s and undefined IsExecutable flag", queryKey)
+	}
 	jsonBody, err := json.Marshal(metadata)
 	if err != nil {
 		return err

--- a/audit.go
+++ b/audit.go
@@ -581,7 +581,7 @@ func (c *Cx1Client) CreateSASTQueryOverride(auditSession *AuditSession, level st
 	}
 
 	if baseQuery.IsExecutable == nil {
-		newQueryData.Executable = true
+		return newQuery, fmt.Errorf("Base query %s has undefined IsExecutable flag, ensure you call GetAuditSASTQuery* or GetAuditSASTQueryMetadata* before overriding or set the metadata manually first.", baseQuery.StringDetailed())
 	} else {
 		newQueryData.Executable = *baseQuery.IsExecutable
 	}

--- a/audit_test.go
+++ b/audit_test.go
@@ -66,7 +66,7 @@ func TestGetAuditSASTQueriesByLevelID(t *testing.T) {
 	}
 
 	var collection SASTQueryCollection
-	collection.AddQueryTree(&querytree, "", "", false)
+	collection.AddQueryTree(&querytree, "", "")
 
 	query := collection.GetQueryByLevelAndName("Cx", "Cx", "JavaScript", "JavaScript_High_Risk", "Client_DOM_XSS")
 	if query == nil {

--- a/audit_v310.go
+++ b/audit_v310.go
@@ -22,7 +22,7 @@ type AuditQuery_v310 struct {
 	Language           string `json:"lang"`
 	Severity           string
 	Cwe                int64
-	IsExecutable       bool
+	IsExecutable       *bool
 	CxDescriptionId    int64
 	QueryDescriptionId string
 	Key                string

--- a/presets.go
+++ b/presets.go
@@ -235,7 +235,7 @@ func (c *Cx1Client) GetSASTPresetQueries() (SASTQueryCollection, error) {
 			return collection, err
 		}
 
-		collection.AddQueryTree(&querytree, "", "", true)
+		collection.AddQueryTree(&querytree, "", "")
 		return collection, nil
 	} else {
 		return c.GetPresetQueries_v330()
@@ -306,7 +306,7 @@ func (c *Cx1Client) GetSASTQueryFamilyContents(family string) (SASTQueryCollecti
 		return collection, err
 	}
 
-	collection.AddQueryTree(&tree, "", "", false)
+	collection.AddQueryTree(&tree, "", "")
 
 	return collection, nil
 }
@@ -515,7 +515,7 @@ func (p Preset) GetSASTQueryCollection(queries SASTQueryCollection) SASTQueryCol
 	for _, fam := range p.QueryFamilies {
 		for _, qid := range fam.QueryIDs {
 			u, _ := strconv.ParseUint(qid, 0, 64)
-			if query := queries.GetQueryByLevelAndID(AUDIT_QUERY.PRODUCT, AUDIT_QUERY.PRODUCT, u); query != nil && query.IsExecutable {
+			if query := queries.GetQueryByLevelAndID(AUDIT_QUERY.PRODUCT, AUDIT_QUERY.PRODUCT, u); query != nil {
 				coll.AddQuery(*query)
 			}
 		}

--- a/presets_v330.go
+++ b/presets_v330.go
@@ -265,7 +265,7 @@ func (c *Cx1Client) GetPresetQueries_v330() (SASTQueryCollection, error) {
 	}
 
 	for i := range queries {
-		queries[i].IsExecutable = true // all queries in the preset are executable
+		queries[i].IsExecutable = boolPtr(true) // all queries in the preset are executable
 
 		if queries[i].Custom {
 			queries[i].Level = c.QueryTypeTenant()

--- a/queries.go
+++ b/queries.go
@@ -30,7 +30,7 @@ type AuditQuery_v312 struct {
 	Language           string `json:"lang"`
 	Severity           string
 	Cwe                int64
-	IsExecutable       bool
+	IsExecutable       *bool
 	CxDescriptionId    int64
 	QueryDescriptionId string
 	Key                string
@@ -217,7 +217,9 @@ func (q *SASTQuery) MergeQuery(nq SASTQuery) {
 	if q.Source == "" && nq.Source != "" {
 		q.Source = nq.Source
 	}
-	q.IsExecutable = nq.IsExecutable
+	if nq.IsExecutable != nil {
+		q.IsExecutable = nq.IsExecutable
+	}
 	if q.CweID == 0 && nq.CweID != 0 {
 		q.CweID = nq.CweID
 	}
@@ -334,8 +336,25 @@ func (q SASTQuery) GetMetadataDiffs(metadata AuditSASTQueryMetadata) []string {
 	}
 
 	if q.IsExecutable != metadata.IsExecutable {
-		diffs = append(diffs,
-			fmt.Sprintf("IsExecutable: %t != %t", q.IsExecutable, metadata.IsExecutable))
+		qexecStr := "undefined"
+		metaexecStr := "undefined"
+
+		if q.IsExecutable != nil {
+			if *q.IsExecutable {
+				qexecStr = "TRUE"
+			} else {
+				qexecStr = "FALSE"
+			}
+		}
+		if metadata.IsExecutable != nil {
+			if *metadata.IsExecutable {
+				metaexecStr = "TRUE"
+			} else {
+				metaexecStr = "FALSE"
+			}
+		}
+
+		diffs = append(diffs, fmt.Sprintf("IsExecutable: %s != %s", qexecStr, metaexecStr))
 	}
 
 	if q.QueryDescriptionId != metadata.CxDescriptionID {

--- a/results.go
+++ b/results.go
@@ -206,7 +206,6 @@ func (c *Cx1Client) GetSASTResultsPredicatesFiltered(filter SASTResultsPredicate
 	}
 
 	return Predicates.PredicateHistoryPerProject[0].Predicates, err
-
 }
 
 func (c *Cx1Client) GetLastSASTResultsPredicateByID(SimilarityID string, ProjectID, ScanID string) (SASTResultsPredicates, error) {

--- a/results.go
+++ b/results.go
@@ -206,6 +206,7 @@ func (c *Cx1Client) GetSASTResultsPredicatesFiltered(filter SASTResultsPredicate
 	}
 
 	return Predicates.PredicateHistoryPerProject[0].Predicates, err
+
 }
 
 func (c *Cx1Client) GetLastSASTResultsPredicateByID(SimilarityID string, ProjectID, ScanID string) (SASTResultsPredicates, error) {

--- a/sastquerycollection.go
+++ b/sastquerycollection.go
@@ -361,7 +361,7 @@ func (qc *SASTQueryCollection) AddQueries(queries *[]SASTQuery) {
 	}
 }
 
-func (qc *SASTQueryCollection) AddQueryTree(t *[]AuditQueryTree, appId, projectId string, setExecutable bool) {
+func (qc *SASTQueryCollection) AddQueryTree(t *[]AuditQueryTree, appId, projectId string) {
 	for _, lang := range *t {
 		for _, level := range lang.Children {
 			isCustom := true
@@ -411,7 +411,6 @@ func (qc *SASTQueryCollection) AddQueryTree(t *[]AuditQueryTree, appId, projectI
 						Language:           lang.Title,
 						Severity:           GetSeverity(GetSeverityID(query.Data.Severity)),
 						CweID:              query.Data.CWE,
-						IsExecutable:       setExecutable,
 						QueryDescriptionId: 0,
 						Custom:             isCustom,
 						EditorKey:          key,
@@ -538,7 +537,7 @@ func (qc SASTQueryCollection) GetQueryFamilies(executableOnly bool) []QueryFamil
 						query := &group.Queries[qid]
 						queryId := fmt.Sprintf("%d", query.QueryID)
 
-						if !slices.Contains(queryFamilies[id].QueryIDs, queryId) && (!executableOnly || query.IsExecutable) {
+						if !slices.Contains(queryFamilies[id].QueryIDs, queryId) && (!executableOnly || (query.IsExecutable != nil && *query.IsExecutable)) {
 							queryFamilies[id].QueryIDs = append(queryFamilies[id].QueryIDs, queryId)
 						}
 					}
@@ -556,7 +555,7 @@ func (qc SASTQueryCollection) GetQueryFamilies(executableOnly bool) []QueryFamil
 					query := &group.Queries[qid]
 					queryId := fmt.Sprintf("%d", query.QueryID)
 
-					if !slices.Contains(newFam.QueryIDs, queryId) && (!executableOnly || query.IsExecutable) {
+					if !slices.Contains(newFam.QueryIDs, queryId) && (!executableOnly || (query.IsExecutable != nil && *query.IsExecutable)) {
 						newFam.QueryIDs = append(newFam.QueryIDs, queryId)
 					}
 				}

--- a/types.go
+++ b/types.go
@@ -399,14 +399,14 @@ type AuditSASTQuery struct {
 	Key      string `json:"id"`
 	Name     string
 	Level    string
-	LevelID  string
+	LevelID  string `json:"-"` // used internally by cx1clientgo
 	Path     string
 	Source   string
-	Metadata AuditSASTQueryMetadata
+	Metadata AuditSASTQueryMetadata // nil unless explicitly requested
 }
 type AuditSASTQueryMetadata struct {
 	Cwe             int64  `json:"cwe,omitempty"`
-	IsExecutable    bool   `json:"executable"`
+	IsExecutable    *bool  `json:"executable,omitempty"`
 	CxDescriptionID int64  `json:"description,omitempty"`
 	Language        string `json:"language"`
 	Group           string `json:"group"`
@@ -1110,7 +1110,7 @@ type SASTQuery struct {
 	Language           string `json:"language"`
 	Severity           string `json:"severity"`
 	CweID              int64  `json:"cweID"`
-	IsExecutable       bool   `json:"isExecutable"`
+	IsExecutable       *bool  `json:"isExecutable,omitempty"`
 	QueryDescriptionId int64  `json:"queryDescriptionId"`
 	Custom             bool   `json:"custom"`
 	EditorKey          string `json:"key"`


### PR DESCRIPTION
* fix buggy isExecutable handling on SASTQuery/AuditQuery

* remove testing proxy from examples

* fix query example for updated isExecutable

* Remove unnecessary newline in GetLastSASTResultsPredicateByID

* remove proxy from examples